### PR TITLE
wildcard_alert_patterns

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,8 +84,9 @@ start analyzing for anomalies!
 ### Alerts
 Skyline can alert you! In your settings.py, add any alerts you want to the ALERTS
 list, according to the schema `(metric keyword, strategy, expiration seconds)` where
-`strategy` is one of `smtp`, `hipchat`, or `pagerduty`. You can also add your own
-alerting strategies. For every anomalous metric, Skyline will search for the given
+`strategy` is one of `smtp`, `hipchat`, or `pagerduty`.  Wildcards can be used in
+the `metric keyword` as well. You can also add your own alerting strategies.
+For every anomalous metric, Skyline will search for the given
 keyword and trigger the corresponding alert(s). To prevent alert fatigue, Skyline
 will only alert once every <expiration seconds> for any given metric/strategy
 combination. To enable Hipchat integration, uncomment the python-simple-hipchat

--- a/src/analyzer/analyzer.py
+++ b/src/analyzer/analyzer.py
@@ -12,6 +12,7 @@ import traceback
 import operator
 import socket
 import settings
+import re
 
 from alerters import trigger_alert
 from algorithms import run_selected_algorithm
@@ -191,7 +192,11 @@ class Analyzer(Thread):
             if settings.ENABLE_ALERTS:
                 for alert in settings.ALERTS:
                     for metric in self.anomalous_metrics:
-                        if alert[0] in metric[1]:
+                        ALERT_MATCH_PATTERN = alert[0]
+                        METRIC_PATTERN = metric[1]
+                        alert_match_pattern = re.compile(ALERT_MATCH_PATTERN)
+                        pattern_match = alert_match_pattern.match(METRIC_PATTERN)
+                        if pattern_match:
                             cache_key = 'last_alert.%s.%s' % (alert[1], metric[1])
                             try:
                                 last_alert = self.redis_conn.get(cache_key)

--- a/src/settings.py.example
+++ b/src/settings.py.example
@@ -120,6 +120,8 @@ ENABLE_ALERTS = True
 #          ("metric1", "smtp", EXPIRATION_TIME),
 #          ("metric2", "pagerduty", EXPIRATION_TIME),
 #          ("metric3", "hipchat", EXPIRATION_TIME),
+# Wildcard namespaces can be used as well
+#          ("metric4.thing.*.requests", "stmp", EXPIRATION_TIME),
 #         )
 ALERTS = (
     ("skyline", "smtp", 1800),


### PR DESCRIPTION
Added the ability to match wildcard metric patterns in the analyzer.py alert
context.
Modified:
readme.md
src/settings.py.example
src/analyzer/analyzer.py
