### PR TITLE
Remove duplicate time import

### DIFF
--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -15,7 +15,6 @@ from os import remove as os_remove
 from time import time, sleep
 
 # @added 20160703 - Feature #1464: Webapp Redis browser
-import time
 from datetime import datetime, timedelta
 import os
 import base64


### PR DESCRIPTION
I was getting this error on startup:

```
2016-07-29 03:58:15 :: 16793 :: webapp.d :: process removed log.wait file, starting log management
2016-07-29 03:58:16 :: 16793 :: webapp.d :: log management done
started with pid 16904
Traceback (most recent call last):
  File "./skyline/webapp/webapp.py", line 809, in <module>
    run()
  File "./skyline/webapp/webapp.py", line 806, in run
    daemon_runner.do_action()
  File "/opt/python_virtualenv/projects/skyline-py2712/lib/python2.7/site-packages/daemon/runner.py", line 267, in do_action
    func(self)
  File "/opt/python_virtualenv/projects/skyline-py2712/lib/python2.7/site-packages/daemon/runner.py", line 186, in _start
    self.app.run()
  File "./skyline/webapp/webapp.py", line 691, in run
    now = time()
TypeError: 'module' object is not callable
```