### PR TITLE
flux py3 changes

### DIFF
--- a/skyline/flux/flux.py
+++ b/skyline/flux/flux.py
@@ -6,28 +6,39 @@ import falcon
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
 
-from logger import set_up_logging
-from listen import MetricData, MetricDataPost
-# from listen_post import MetricDataPost
-from worker import Worker
-from populate_metric import PopulateMetric
-from populate_metric_worker import PopulateMetricWorker
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    from logger import set_up_logging
+    from listen import MetricData, MetricDataPost
+    # from listen_post import MetricDataPost
+    from worker import Worker
+    from populate_metric import PopulateMetric
+    from populate_metric_worker import PopulateMetricWorker
 
 logger = set_up_logging(None)
 pid = os.getpid()
-logger.info('flux :: starting flux with pid %s' % str(pid))
+logger.info('flux :: starting flux listening on %s with pid %s' % (str(settings.FLUX_IP), str(pid)))
 
 logger.info('flux :: starting worker')
 # @modified 20191010 - Bug #3254: flux.populateMetricQueue Full
 # httpMetricDataQueue = Queue(maxsize=3000)
-httpMetricDataQueue = Queue(maxsize=30000)
+# @modified 20191129 - Bug #3254: flux.populateMetricQueue Full
+# Set to infinite
+#httpMetricDataQueue = Queue(maxsize=30000)
+httpMetricDataQueue = Queue(maxsize=0)
 Worker(httpMetricDataQueue, pid).start()
 
 # @modified 20191010 - Bug #3254: flux.populateMetricQueue Full
 # populateMetricQueue = Queue(maxsize=3000)
-populateMetricQueue = Queue(maxsize=30000)
+# @modified 20191116 - Bug #3254: flux.populateMetricQueue Full
+# @modified 20191129 - Bug #3254: flux.populateMetricQueue Full
+# Set to infinite
+#populateMetricQueue = Queue(maxsize=300000)
+populateMetricQueue = Queue(maxsize=0)
+
 logger.info('flux :: starting populate_metric_worker')
 PopulateMetricWorker(populateMetricQueue, pid).start()
 

--- a/skyline/flux/gunicorn.py
+++ b/skyline/flux/gunicorn.py
@@ -9,7 +9,11 @@ from logger import set_up_logging
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
+
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
 
 bind = '%s:%s' % (settings.FLUX_IP, str(settings.FLUX_PORT))
 # workers = multiprocessing.cpu_count() * 2 + 1

--- a/skyline/flux/listen.py
+++ b/skyline/flux/listen.py
@@ -10,13 +10,19 @@ import falcon
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
-import flux
 
-logger = set_up_logging('listen')
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    import flux
 
-# LOCAL_DEBUG = False
-LOCAL_DEBUG = True
+# @modified 20191129 - Branch #3262: py3
+# Consolidate flux logging
+# logger = set_up_logging('listen')
+logger = set_up_logging(None)
+
+LOCAL_DEBUG = False
 
 
 def validate_key(caller, apikey):
@@ -211,6 +217,14 @@ class MetricData(object):
             logger.error('error :: listen :: failed to add GET request data to flux.httpMetricDataQueue - %s' % str(metric_data))
             resp.status = falcon.HTTP_500
             return
+
+        if LOCAL_DEBUG:
+            try:
+                queue_size = flux.httpMetricDataQueue.qsize()
+                logger.info('listen :: flux.httpMetricDataQueue.qsize - %s' % str(queue_size))
+            except:
+                logger.error(traceback.format_exc())
+                logger.error('error :: listen :: failed to determine flux.httpMetricDataQueue.qsize')
 
         if LOCAL_DEBUG:
             resp.body = json.dumps(payload)

--- a/skyline/flux/logger.py
+++ b/skyline/flux/logger.py
@@ -9,6 +9,8 @@ import os.path
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
 
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
 if True:
     import settings
 

--- a/skyline/flux/populate_metric.py
+++ b/skyline/flux/populate_metric.py
@@ -10,15 +10,21 @@ import graphyte
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
-# @added 20191111 - Bug #3266: py3 Redis binary objects not strings
-#                   Branch #3262: py3
-from skyline_functions import get_redis_conn
 
-from logger import set_up_logging
-import flux
+if True:
+    import settings
+    # @added 20191111 - Bug #3266: py3 Redis binary objects not strings
+    #                   Branch #3262: py3
+    from skyline_functions import get_redis_conn
 
-logger = set_up_logging('populate_metric')
+    from logger import set_up_logging
+    import flux
+
+# @modified 20191129 - Branch #3262: py3
+# Consolidate flux logging
+# logger = set_up_logging('populate_metric')
+logger = set_up_logging(None)
+
 # URI arguments are solely used for identifying requests in the log, all the
 # required metric data is submitted via a POST with a json payload.
 validArguments = ['remote_target', 'metric', 'namespace_prefix', 'key', 'user']

--- a/skyline/flux/worker.py
+++ b/skyline/flux/worker.py
@@ -2,7 +2,10 @@ import sys
 import os.path
 from os import kill
 import traceback
-from multiprocessing import Queue, Process
+# @modified 20191115 - Branch #3262: py3
+# from multiprocessing import Queue, Process
+from multiprocessing import Process
+
 try:
     from Queue import Empty  # Python 2.7
 except ImportError:
@@ -10,17 +13,28 @@ except ImportError:
 from time import sleep, time
 from ast import literal_eval
 
-from redis import StrictRedis
+# from redis import StrictRedis
 import graphyte
 import statsd
 
 from logger import set_up_logging
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
-from skyline_functions import send_graphite_metric
 
-logger = set_up_logging('worker')
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    from skyline_functions import (
+        send_graphite_metric,
+        # @added 20191111 - Bug #3266: py3 Redis binary objects not strings
+        #                   Branch #3262: py3
+        get_redis_conn, get_redis_conn_decoded)
+
+# @modified 20191129 - Branch #3262: py3
+# Consolidate flux logging
+# logger = set_up_logging('worker')
+logger = set_up_logging(None)
 
 try:
     SERVER_METRIC_PATH = '.%s' % settings.SERVER_METRICS_NAME
@@ -36,6 +50,8 @@ parent_skyline_app = 'flux'
 skyline_app = 'flux'
 
 skyline_app_graphite_namespace = 'skyline.%s%s.worker' % (parent_skyline_app, SERVER_METRIC_PATH)
+
+LOCAL_DEBUG = False
 
 if settings.FLUX_SEND_TO_CARBON:
     GRAPHITE_METRICS_PREFIX = None
@@ -70,10 +86,17 @@ class Worker(Process):
     """
     def __init__(self, queue, parent_pid):
         super(Worker, self).__init__()
-        if settings.REDIS_PASSWORD:
-            self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
-        else:
-            self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+        # @modified 20191115 - Bug #3266: py3 Redis binary objects not strings
+        #                      Branch #3262: py3
+        # if settings.REDIS_PASSWORD:
+        #     self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
+        # else:
+        #     self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+        # @added 20191115 - Bug #3266: py3 Redis binary objects not strings
+        #                   Branch #3262: py3
+        self.redis_conn = get_redis_conn(skyline_app)
+        self.redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+
         self.q = queue
         self.parent_pid = parent_pid
         self.daemon = True
@@ -110,10 +133,24 @@ class Worker(Process):
                 except:
                     logger.error('worker :: cannot connect to redis at socket path %s' % (settings.REDIS_SOCKET_PATH))
                     sleep(2)
-                    if settings.REDIS_PASSWORD:
-                        self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
-                    else:
-                        self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+                    # @modified 20191115 - Bug #3266: py3 Redis binary objects not strings
+                    #                      Branch #3262: py3
+                    # Use get_redis_conn and get_redis_conn_decoded
+                    # if settings.REDIS_PASSWORD:
+                    #     self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
+                    # else:
+                    #     self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+                    self.redis_conn = get_redis_conn(skyline_app)
+                    self.redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+
+            if LOCAL_DEBUG:
+                try:
+                    metric_data_queue_size = self.q.qsize()
+                    logger.info('worker :: debug :: flux.httpMetricDataQueue queue size - %s' % str(metric_data_queue_size))
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: worker :: failed to determine size of queue flux.httpMetricDataQueue')
+
             metric_data = None
             try:
                 # Get a metric from the queue with a 1 second timeout, each
@@ -138,6 +175,8 @@ class Worker(Process):
                     metric = str(metric_data[0])
                     value = float(metric_data[1])
                     timestamp = int(metric_data[2])
+                    if LOCAL_DEBUG:
+                        logger.info('worker :: debug :: queue item found - %s' % str(metric_data))
                 except:
                     logger.error(traceback.format_exc())
                     logger.error('error :: worker :: failed to interpolate metric, value, timestamp from metric_data - %s' % str(metric_data))
@@ -149,20 +188,30 @@ class Worker(Process):
                     cache_key = 'flux.last.%s' % metric
                     last_metric_timestamp = None
                     try:
-                        redis_last_metric_data = self.redis_conn.get(cache_key)
+                        # @modified 20191128 - Bug #3266: py3 Redis binary objects not strings
+                        #                      Branch #3262: py3
+                        # redis_last_metric_data = self.redis_conn.get(cache_key)
+                        redis_last_metric_data = self.redis_conn_decoded.get(cache_key)
                         last_metric_data = literal_eval(redis_last_metric_data)
                         last_metric_timestamp = int(last_metric_data[0])
+                        if LOCAL_DEBUG:
+                            logger.info('worker :: debug :: last_metric_timestamp for %s from %s is %s' % (metric, str(cache_key), str(last_metric_timestamp)))
                     except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: worker :: failed to determine last_metric_timestamp from Redis key %s' % str(cache_key))
                         last_metric_timestamp = False
                     if last_metric_timestamp:
                         if timestamp <= last_metric_timestamp:
                             valid_data = False
+                            if LOCAL_DEBUG:
+                                logger.info('worker :: debug :: not valid data - the queue data timestamp %s is <= to the last_metric_timestamp %s for %s' % (
+                                    str(timestamp), str(last_metric_timestamp), metric))
                     if valid_data:
                         submittedToGraphite = False
                         try:
                             graphyte.send(metric, value, timestamp)
                             submittedToGraphite = True
-                            logger.info('worker :: sent %s, %s, %s to Graphite' % (metric, str(value), str(timestamp)))
+                            logger.info('worker :: sent %s, %s, %s to Graphite' % (str(metric), str(value), str(timestamp)))
                             metrics_sent_to_graphite += 1
                         except:
                             logger.error(traceback.format_exc())
@@ -173,8 +222,11 @@ class Worker(Process):
                             metric_data = [timestamp, value]
                             self.redis_conn.set(cache_key, str(metric_data))
                     else:
-                        logger.info('worker discarded %s, %s, %s as a data point for %s has already been submitted to Graphite' % (
-                            metric, str(value), str(timestamp), str(timestamp)))
+                        logger.info('worker :: discarded %s, %s, %s as a data point for %s has already been submitted to Graphite' % (
+                            str(metric), str(value), str(timestamp), str(timestamp)))
+                else:
+                    logger.info('worker :: settings.FLUX_SEND_TO_CARBON is set to %s, discarded %s, %s, %s' % (
+                        str(settings.FLUX_SEND_TO_CARBON), str(metric), str(value), str(timestamp)))
 
                 if settings.FLUX_SEND_TO_STATSD:
                     statsd_conn.incr(metric, value, timestamp)


### PR DESCRIPTION
IssueID #3266: py3 Redis binary objects not strings
IssueID #3254: flux.populateMetricQueue Full
IssueID #3262: py3

- Set Queue size to 0 infinite
- Consolidate flux logging
- Prevent flake8 E402 - module level import not at top of file
- Use new redis functions

Modified:
skyline/flux/flux.py
skyline/flux/gunicorn.py
skyline/flux/listen.py
skyline/flux/logger.py
skyline/flux/populate_metric.py
skyline/flux/populate_metric_worker.py
skyline/flux/worker.py