### PR TITLE
horizon py3 changes

### DIFF
--- a/skyline/horizon/agent.py
+++ b/skyline/horizon/agent.py
@@ -2,7 +2,10 @@ import logging
 import time
 import sys
 from os import getpid
-from os.path import dirname, abspath, isdir, join
+# @modified 20191115 - Branch #3262: py3
+# from os.path import dirname, abspath, isdir, join
+from os.path import isdir
+
 from multiprocessing import Queue
 from daemon import runner
 from logging.handlers import TimedRotatingFileHandler, MemoryHandler
@@ -10,12 +13,15 @@ from logging.handlers import TimedRotatingFileHandler, MemoryHandler
 import os.path
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
-from validate_settings import validate_settings_variables
 
-from listen import Listen
-from roomba import Roomba
-from worker import Worker
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    from validate_settings import validate_settings_variables
+    from listen import Listen
+    from roomba import Roomba
+    from worker import Worker
 
 skyline_app = 'horizon'
 skyline_app_logger = '%sLog' % skyline_app
@@ -134,6 +140,7 @@ def run():
         daemon_runner = runner.DaemonRunner(horizon)
         daemon_runner.daemon_context.files_preserve = [handler.stream]
         daemon_runner.do_action()
+
 
 if __name__ == "__main__":
     run()

--- a/skyline/horizon/listen.py
+++ b/skyline/horizon/listen.py
@@ -207,7 +207,7 @@ class Listen(Process):
                     data = new_data
                 if LOCAL_DEBUG:
                     logger.debug('debug :: listen :: read_all with chunk - %s' % str(chunk))
-            except Exception as e:
+            except:
                 if LOCAL_DEBUG:
                     logger.error(traceback.format_exc())
                     logger.error('error :: listen :: read_all with chunk - %s' % str(chunk))

--- a/skyline/horizon/roomba.py
+++ b/skyline/horizon/roomba.py
@@ -1,5 +1,8 @@
 from __future__ import division
-from os import kill, getpid
+# @modified 20191115 - Branch #3262: py3
+# from os import kill, getpid
+from os import kill
+
 from redis import StrictRedis, WatchError
 from multiprocessing import Process
 from threading import Thread
@@ -10,7 +13,7 @@ except ImportError:
     eliminated_in_python3 = True
 from time import time, sleep
 from math import ceil
-import traceback
+# import traceback
 import logging
 
 import sys
@@ -18,12 +21,16 @@ import os.path
 from os import remove as os_remove
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
-import settings
-# @added 20191030 - Bug #3266: py3 Redis binary objects not strings
-#                   Branch #3262: py3
-# Added a single functions to deal with Redis connection and the
-# charset='utf-8', decode_responses=True arguments required in py3
-from skyline_functions import get_redis_conn, get_redis_conn_decoded
+
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    # @added 20191030 - Bug #3266: py3 Redis binary objects not strings
+    #                   Branch #3262: py3
+    # Added a single functions to deal with Redis connection and the
+    # charset='utf-8', decode_responses=True arguments required in py3
+    from skyline_functions import get_redis_conn, get_redis_conn_decoded
 
 parent_skyline_app = 'horizon'
 child_skyline_app = 'roomba'
@@ -272,10 +279,17 @@ class Roomba(Thread):
                     (skyline_app, settings.REDIS_SOCKET_PATH))
                 sleep(10)
                 # @modified 20180519 - Feature #2378: Add redis auth to Skyline and rebrow
+                # @modified 20191115 - Bug #3266: py3 Redis binary objects not strings
+                #                      Branch #3262: py3
                 if settings.REDIS_PASSWORD:
                     self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
                 else:
                     self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+                # @added 20191115 - Bug #3266: py3 Redis binary objects not strings
+                #                   Branch #3262: py3
+                self.redis_conn = get_redis_conn(skyline_app)
+                self.redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+
                 continue
 
             # Spawn processes


### PR DESCRIPTION
IssueID #3266: py3 Redis binary objects not strings
IssueID #3262: py3

- Prevent flake8 E402 - module level import not at top of file
- Use new redis functions

Modified:
skyline/horizon/agent.py
skyline/horizon/listen.py
skyline/horizon/roomba.py