### PR TITLE
luminosity py3 changes

### DIFF
--- a/skyline/luminosity/agent.py
+++ b/skyline/luminosity/agent.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-# import traceback
+import traceback
 from os import getpid
 from os.path import isdir
 from daemon import runner
@@ -17,10 +17,12 @@ import os.path
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
 
-import settings
-from validate_settings import validate_settings_variables
-
-from luminosity import Luminosity
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    from validate_settings import validate_settings_variables
+    from luminosity import Luminosity
 
 skyline_app = 'luminosity'
 skyline_app_logger = skyline_app + 'Log'

--- a/skyline/luminosity/luminosity.py
+++ b/skyline/luminosity/luminosity.py
@@ -3,10 +3,13 @@ import logging
 import os
 from os import kill, getpid
 from sys import version_info
-try:
-    from Queue import Empty
-except:
-    from queue import Empty
+
+# @modified 20191115 - Branch #3262: py3
+# try:
+#     from Queue import Empty
+# except:
+#     from queue import Empty
+
 from time import time, sleep
 from threading import Thread
 # @modified 20190522 - Task #3034: Reduce multiprocessing Manager list usage
@@ -502,10 +505,19 @@ class Luminosity(Thread):
                     settings.REDIS_SOCKET_PATH))
                 sleep(30)
                 # @modified 20180519 - Feature #2378: Add redis auth to Skyline and rebrow
-                if settings.REDIS_PASSWORD:
-                    self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
-                else:
-                    self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+                # @modified 20191115 - Bug #3266: py3 Redis binary objects not strings
+                #                      Branch #3262: py3
+                # Use get_redis_conn and get_redis_conn_decoded to use on Redis sets when the bytes
+                # types need to be decoded as utf-8 to str
+                # if settings.REDIS_PASSWORD:
+                #     self.redis_conn = StrictRedis(password=settings.REDIS_PASSWORD, unix_socket_path=settings.REDIS_SOCKET_PATH)
+                # else:
+                #     self.redis_conn = StrictRedis(unix_socket_path=settings.REDIS_SOCKET_PATH)
+                # @added 20191115 - Bug #3266: py3 Redis binary objects not strings
+                #                   Branch #3262: py3
+                self.redis_conn = get_redis_conn(skyline_app)
+                self.redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+
                 continue
 
             # Report app up

--- a/skyline/luminosity/process_correlations.py
+++ b/skyline/luminosity/process_correlations.py
@@ -1,8 +1,10 @@
 import logging
-# from redis import StrictRedis
+from redis import StrictRedis
 from msgpack import Unpacker
 import traceback
-from math import ceil
+# @modified 20191115 - Branch #3262: py3
+# from math import ceil
+
 from luminol.anomaly_detector import AnomalyDetector
 from luminol.correlator import Correlator
 from timeit import default_timer as timer


### PR DESCRIPTION
IssueID #3266: py3 Redis binary objects not strings
IssueID #3262: py3

- Prevent flake8 E402 - module level import not at top of file
- Use new redis functions

Modified:
skyline/luminosity/agent.py
skyline/luminosity/luminosity.py
skyline/luminosity/process_correlations.py