### PR TITLE
new features

### DIFF
--- a/skyline/boundary/boundary_algorithms.py
+++ b/skyline/boundary/boundary_algorithms.py
@@ -11,17 +11,19 @@ import os.path
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, os.path.dirname(__file__))
 
-from settings import (
-    MAX_TOLERABLE_BOREDOM,
-    MIN_TOLERABLE_LENGTH,
-    STALE_PERIOD,
-    REDIS_SOCKET_PATH,
-    BOREDOM_SET_SIZE,
-    ENABLE_BOUNDARY_DEBUG,
-    REDIS_PASSWORD,
-)
-
-from algorithm_exceptions import (TooShort, Stale, Boring)
+# @modified 20200122 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    from settings import (
+        MAX_TOLERABLE_BOREDOM,
+        MIN_TOLERABLE_LENGTH,
+        STALE_PERIOD,
+        REDIS_SOCKET_PATH,
+        BOREDOM_SET_SIZE,
+        ENABLE_BOUNDARY_DEBUG,
+        REDIS_PASSWORD,
+    )
+    from algorithm_exceptions import (TooShort, Stale, Boring)
 
 skyline_app = 'boundary'
 skyline_app_logger = '%sLog' % skyline_app

--- a/skyline/ionosphere/ionosphere.py
+++ b/skyline/ionosphere/ionosphere.py
@@ -1223,7 +1223,9 @@ class Ionosphere(Thread):
                 # @modified 20191114 - Feature #: forward_alert
                 # Allow ionosphere to check any metrics that have an alerter other than smtp set, apart from syslog
 
-                logger.error('error :: Ionosphere does not handle metrics that do not have a smtp alert context removing check for %s' % (base_name))
+                # logger.error('error :: Ionosphere does not handle metrics that do not have a smtp alert context removing check for %s' % (base_name))
+                logger.info('Ionosphere does not handle metrics that do not have a smtp alert context removing check for %s which is a training_metric' % (base_name))
+
                 self.remove_metric_check_file(str(metric_check_file))
                 if engine:
                     engine_disposal(engine)

--- a/skyline/ionosphere/learn.py
+++ b/skyline/ionosphere/learn.py
@@ -581,7 +581,7 @@ def ionosphere_learn(timestamp):
                         redis_conn.srem(work_set, str(learn_metric_list))
                     except:
                         logger.error(traceback.format_exc())
-                        logger.error('error :: learn :: failed remove %s from Redis set %s')
+                        logger.error('error :: learn :: failed remove %s from Redis set %s' % (str(learn_metric_list), work_set))
                 else:
                     logger.info('learn :: exiting this work but not removing work item, as database may be available again before the work expires')
                 learn_engine_disposal(engine)

--- a/skyline/ionosphere_functions.py
+++ b/skyline/ionosphere_functions.py
@@ -420,7 +420,8 @@ def create_features_profile(current_skyline_app, requested_timestamp, data_for_m
                         continue
                     if feature_name_item:
                         fname_id = feature_name_item[0]
-                        current_logger.debug('debug :: fname_id - %s' % str(fname_id))
+                        if LOCAL_DEBUG:
+                            current_logger.debug('debug :: fname_id - %s' % str(fname_id))
                     f_value = str(line[1])
                 if fname_id and f_value:
                     features_data.append([fname_id, f_value])

--- a/skyline/mirage/mirage.py
+++ b/skyline/mirage/mirage.py
@@ -1689,8 +1689,16 @@ class Mirage(Thread):
 
                                 try:
                                     if alert[1] != 'smtp':
+                                        logger.info('trigger_alert :: alert: %s, metric: %s, second_order_resolution_seconds: %s, context: %s' % (
+                                            str(alert), str(metric),
+                                            str(second_order_resolution_seconds),
+                                            str(alert_context)))
                                         trigger_alert(alert, metric, second_order_resolution_seconds, alert_context)
                                     else:
+                                        logger.info('smtp_trigger_alert :: alert: %s, metric: %s, second_order_resolution_seconds: %s, context: %s' % (
+                                            str(alert), str(metric),
+                                            str(second_order_resolution_seconds),
+                                            str(alert_context)))
                                         smtp_trigger_alert(alert, metric, second_order_resolution_seconds, alert_context)
                                     logger.info('sent %s alert: For %s' % (alert[1], metric[1]))
                                 except Exception as e:

--- a/utils/verify_alerts.py
+++ b/utils/verify_alerts.py
@@ -2,7 +2,7 @@ import os
 import sys
 from os.path import dirname, join, realpath
 from optparse import OptionParser
-from time import sleep
+from time import sleep, time
 import logging
 
 # Get the current working directory of this file.
@@ -100,6 +100,6 @@ if boundary_alerts_enabled:
         if alert[0] == options.metric:
             if options.trigger in alert[7]:
                 print('    Testing Boundary alerting against "' + alert[0] + '" to send for ' + alert[7] + ' via ' + options.trigger)
-                trigger_alert(options.trigger, '0', alert[0], '1', '1', 'test')
+                trigger_alert(options.trigger, '0', alert[0], '1', '1', 'test', int(time()))
 else:
     print('Boundary alerts are disabled')


### PR DESCRIPTION
IssueID #3396: http_alerter
IssueID #3400: Identify air gaps in the metric data
IssueID #3406: Allow for no_email SMTP_OPTS
IssueID #3262: py3

- Added changes to analyzer.py, alerters.py, mirage.py, mirage_alerters.py,
  boundary.py and boundary_alerters.py related to the addition of a http_alerter
  alert type (3396)
- Added http_alerter_ example to ALERTS and BOUNDARY_METRICS and added
  HTTP_ALERTERS_OPTS and BOUNDARY_HTTP_ALERTERS_OPTS to settings.py (3396)
- Added mock_api alert_receiver endpoint to webapp.py for testing (3396)
- Allow Analyzer to identify air gapped metrics, handled in algorithms.py,
  webapp.py via /api?airgapped_metrics and in settings.py (3400)
- Allow for the use of 'no_email' in SMTP_OPTS to fake email.  Allowed for in
  alerters.py and mirage_alerters.py (3406)
- Use file not buf.seek in mirage_alerters.py and prevent flake8 E402 in
  boundary_algorithms.py and corrected some logging in ionosphere files (3262)

Modified:
skyline/analyzer/alerters.py
skyline/analyzer/algorithms.py
skyline/analyzer/analyzer.py
skyline/boundary/boundary.py
skyline/boundary/boundary_alerters.py
skyline/boundary/boundary_algorithms.py
skyline/ionosphere/ionosphere.py
skyline/ionosphere/learn.py
skyline/ionosphere_functions.py
skyline/mirage/mirage.py
skyline/mirage/mirage_alerters.py
skyline/settings.py
skyline/webapp/webapp.py
utils/verify_alerts.py