### PR TITLE
webapp api - alerting_metrics and non_alerting_metrics

### DIFF
--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -1,0 +1,13 @@
+{% extends "layout.html" %}
+{% block body %}
+
+<!-- BEGIN /now block -->
+  <script src="/static/js/skyline.js"></script>
+	<ol class="breadcrumb">
+		<li><a href="/">Home</a></li>
+		<li><a href="/api">api</a></li>
+		<li class="active"><span class="logo"><span class="sky">api</span> <span class="re">documentation</span></li>
+	</ol>
+
+<!-- END /api block -->
+{% endblock %}


### PR DESCRIPTION
IssueID #3422: webapp api - alerting_metrics and non_alerting_metrics
IssueID #3424: webapp - api documentation

- Added alerting_metrics and non_alerting_metrics webapp API endpoint methods
  to return aet.analyzer.non_smtp_alerter_metrics and
  aet.analyzer.smtp_alerter_metrics Redis sets as json (3422)
- Added initial blocks for documentation of the webapp API methods (3424)

Added:
skyline/webapp/templates/api.html
Modified:
skyline/webapp/webapp.py