### PR TITLE
webapp api - training_data

### DIFF
--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -628,7 +628,8 @@ Or if no metrics if all metrics are set to alert <code>{"data":{"metrics":[]},"s
   		        <td>Description:</td>
   		        <td>Returns a list of all metrics and their anomaly timestamps which have training data.<br>
                   The <code>metric</code> and <code>timestamp</code> request arguments can be added to
-                  filter by metric, timestamp or by metric and timestamp.
+                  filter by metric, namespace, timestamp or by metric and timestamp.
+                  You can also use part of namespace as the <code>metric</code> and all metrics that match the namespace will be returned
               </td>
   		      </tr>
   		      <tr>

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -581,6 +581,19 @@ def api():
                 if metric_filter:
                     if metric_filter != training_metric:
                         add_to_response = False
+
+                    # @added 20200417 - Feature #3474: webapp api - training_data
+                    # Allow to match namespaces too
+                    if not add_to_response:
+                        if metric_filter in training_metric:
+                            add_to_response = True
+                    if not add_to_response:
+                        metric_filter_namespace_elements = metric_filter.split('.')
+                        training_metric_namespace_elements = training_metric.split('.')
+                        elements_matched = set(metric_filter_namespace_elements) & set(training_metric_namespace_elements)
+                        if len(elements_matched) == len(metric_filter_namespace_elements):
+                            add_to_response = True
+
                 if timestamp_filter:
                     if int(timestamp_filter) != training_timestamp:
                         add_to_response = False


### PR DESCRIPTION
IssueID #3474: webapp api - training_data

- Allow to match namespaces too

Modified:
skyline/webapp/templates/api.html
skyline/webapp/webapp.py