### PR TITLE
upload_data - flux and webapp

### DIFF
--- a/docs/upload-data-to-flux.rst
+++ b/docs/upload-data-to-flux.rst
@@ -2,6 +2,8 @@
 upload_data to Flux - EXPERIMENTAL
 ==================================
 
+**POST variables may change as this is a experimental feature**
+
 **SIMPLE** data files can be uploaded via the /upload_data HTTP/S endpoint for
 Flux to process and fed to Graphite.  A number of things need to be enabled and
 running to allow for processing data file uploads, which are not enabled by
@@ -15,15 +17,18 @@ Skyline currently allows for the uploading of the following format data files:
 
 - csv (tested)
 - xlsx (tested)
+- xls (not tested)
 
 Seeing as data files can be large, the following archive formats are accepted:
 
 - gz (tested)
-- zip (tested)
+- zip (partly tested, multiple data files per archive have not been thoroughly tested)
 
 A single file or archive can be uploaded or many data files can be uploaded in
 a single archive.  A `info.csv` must also be included in the archive, more
-on that below.
+on that below.  **HOWEVER** if you wish to determine the status of the upload
+programmatically you will want to upload one data file per upload, otherwise
+making sense of the upload_status will be very difficult.
 
 So you could upload `data.csv`, `data.csv.gz` or `data.zip` with the `data.csv`
 file inside the zip archive.
@@ -94,12 +99,19 @@ info.json
 
 Your date time column MUST be named date in the columns_to_metrics mapping.
 
-For convenience sake you can also add two additional elements to the info.json:
+For convenience sake you can also add additional elements to the info.json:
 
 - `"debug": "true"` which outputs additional information regarding the imported
   dataframe in the flux.log to aid with debugging.
 - `"dryrun": "true"` which runs through the processing but does not submit data
   to Graphite.
+- `"ignore_submitted_timestamps": "true"`, a check is normally done of the last
+  timestamp submitted to flux for the metric to ensure that data is not
+  submitted multiple times. If you wish to override this check to resubmit data,
+  update or override already submitted data pass this in the info.json. However
+  do **note**,  if you wish to resubmit data that is **NOT IN THE** latest
+  Graphite retention (old data) this will not have the desired affect as
+  Graphite down sampling (aggregation) will already have occurred.
 
 This tells Skyline what the parent metric namespace should be which would
 result in metrics:

--- a/skyline/webapp/templates/upload_data.html
+++ b/skyline/webapp/templates/upload_data.html
@@ -105,6 +105,7 @@
   		        <td><select name="format">
                 <option value="csv">csv</option>
                 <option value="xlsx">xlsx</option>
+                <option value="xls">xls</option>
               </select><br>
   		      </tr>
   		      <tr>
@@ -172,6 +173,17 @@
               </select><br>
               If you data file has a sample rate of more than 1 data point per metric per 60 seconds, a pandas resample at <code>1Min</code> is appied to the data.<br>
               If the data needs to be resampled, you can select to resample it by the mean (default) or the sum.<br>
+  		      </tr>
+  		      <tr>
+              <td>ignore_submitted_timestamps [optional]</td>
+  		        <td><select name="ignore_submitted_timestamps">
+                <option value="false">false</option>
+                <option value="true">true</option>
+              </select><br>
+              A check is normally done of the last timestamp submitted to flux for the metric to ensure that data is not submitted multiple times<br>
+              If you wish to override this check to resubmit data, update or override already submitted data set this to <code>true</code><br>
+              <strong>Note</strong>: If you wish to resubmit data that is <code>NOT IN THE</code> latest Graphite retention (old data) this will not have the desired affect.<br>
+              If you are submit data for the first time probably set this to true.
   		      </tr>
   		    </tbody>
   		  </table>


### PR DESCRIPTION
IssueID #3538: webapp - upload_data endpoint
IssueID #3550: flux.uploaded_data_worker

- Added ability to ignore_submitted_timestamps to enable no checking of the
  flux.last metric key and simply submit data to Graphite
- Added xls format

Modified:
docs/upload-data-to-flux.rst
skyline/flux/uploaded_data_worker.py
skyline/webapp/templates/upload_data.html
skyline/webapp/webapp.py