### PR TITLE
flux.uploaded_data_worker - flux.sort_and_dedup.metrics

### DIFF
--- a/skyline/flux/uploaded_data_worker.py
+++ b/skyline/flux/uploaded_data_worker.py
@@ -1258,6 +1258,14 @@ class UploadedDataWorker(Process):
                                     elif ignore_submitted_timestamps:
                                         logger.info('uploaded_data_worker :: ignore_submitted_timestamps :: not updating %s with %s' % (
                                             cache_key, str(metric_data)))
+                                        # @added 20200527 - Feature #3550: flux.uploaded_data_worker
+                                        # If submitted timestamps are ignored
+                                        # add the the Redis set for analyzer to
+                                        # sorted and deduplicated the time
+                                        # series data in Redis
+                                        self.redis_conn.sadd('flux.sort_and_dedup.metrics', metric)
+                                        logger.info('uploaded_data_worker :: added %s to flux.sort_and_dedup.metrics Redis set' % (
+                                            metric))
                                     else:
                                         self.redis_conn.set(cache_key, str(metric_data))
                                         logger.info('uploaded_data_worker :: set the metric Redis key - %s - %s' % (

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -4680,8 +4680,8 @@ def upload_data():
     date_orientation = 'rows'
     skip_rows = None
     header_row = None
-    columns_to_ignore = 0
-    columns_to_process = 0
+    columns_to_ignore = None
+    columns_to_process = None
     resample_method = 'mean'
     json_response = False
     flux_identifier = None


### PR DESCRIPTION
IssueID #3550: flux.uploaded_data_worker

- Sort Redis data if upload has passed the ignore_submitted_timestamps using the
  flux.sort_and_dedup.metrics Redis set
- Change 0 to None on columns_to_ignore and columns_to_process in webapp

Modified:
skyline/analyzer/analyzer.py
skyline/flux/uploaded_data_worker.py
skyline/webapp/webapp.py