### PR TITLE
Ensure derivative metic key is always set

### DIFF
--- a/skyline/skyline_functions.py
+++ b/skyline/skyline_functions.py
@@ -1314,6 +1314,13 @@ def strictly_increasing_monotonicity(timeseries):
     monotonically, it will only return True if the values are strictly
     increasing, an incrementing count.
     """
+
+    # @added 20200529 - Bug #2050: analyse_derivatives - change in monotonicity
+    # Only apply to time series that have sufficient data to make this
+    # determination
+    if len(timeseries) < 90:
+        return False
+
     import numpy as np
 
     test_ts = []


### PR DESCRIPTION
IssueID #3480: batch_processing
IssueID #2050: analyse_derivatives - change in monotonicity
IssueID #3508: ionosphere.untrainable_metrics
IssueID #3400: Identify air gaps in the metric data

- Ensure derivative metic key is always set in both analyzer and analyzer_batch
  to prevent analyzer removing the metric from the derivative_metrics when the
  metric is identified and added as such in analyzer_batch (3480, 2050)
- In skyline_functions.py only apply strictly_increasing_monotonicity to time
  series that have sufficient data to make this determination (3480, 2050)
- Check to non 3sigma algorithm errors too in analyzer, added
  check_algorithm_errors to replace settings.ALGORITHMS in the check for errors
  which appends negatives_present and identify_airgaps to the ALGORITHMS to
  check for errors (3508, 3400)
- Update Mirage doc

Modified:
docs/mirage.rst
skyline/analyzer/analyzer.py
skyline/analyzer/analyzer_batch.py
skyline/skyline_functions.py