### PR TITLE
custom algorithms - MIRAGE_ALWAYS_METRICS

### DIFF
--- a/docs/algorithms/custom-algorithms.rst
+++ b/docs/algorithms/custom-algorithms.rst
@@ -276,6 +276,20 @@ This is an example of a more complex custom algorithm structure, that uses
 
 https://github.com/earthgecko/skyline/tree/master/skyline/custom_algorithms/last_same_hours.py
 
+Running a Mirage only custom algorithm on a metric all the time
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Normally for Analyzer to push a metric to Mirage, Analyzer would have to trigger
+on it as anomalous.  However if you wish to run a custom algorithm on a metric
+that requires ``SECOND_ORDER_RESOLUTION_HOURS`` of data to run against as the
+:mod:`settings.FULL_DURATION` data is not sufficient for the custom algorithm,
+perhaps due to seasonality, then you need to declare the metric in
+:mod:`settings.MIRAGE_ALWAYS_METRICS`.  This will cause Analyzer to add the
+metric to Mirage on every run.  Note that the metric needs to be defined as a
+mirage enabled metric in the normal way, ensuring it matches a smtp alert
+defined in :mod:`settings.ALERTS` with a ``SECOND_ORDER_RESOLUTION_HOURS``
+declared.
+
 Some things to consider
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/skyline/mirage/mirage_algorithms.py
+++ b/skyline/mirage/mirage_algorithms.py
@@ -654,6 +654,10 @@ def run_selected_algorithm(timeseries, metric_name, second_order_resolution_seco
                 if DEBUG_CUSTOM_ALGORITHMS or debug_logging:
                     logger.debug('debug :: algorithms :: run_3sigma_algorithms is False on %s for %s' % (
                         custom_algorithm, base_name))
+            else:
+                if DEBUG_CUSTOM_ALGORITHMS or debug_logging:
+                    logger.debug('debug :: algorithms :: run_3sigma_algorithms will now be run on %s' % (
+                        base_name))
             if result:
                 try:
                     custom_consensus = custom_algorithms_to_run[custom_algorithm]['consensus']

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -1519,11 +1519,12 @@ MIRAGE_PERIODIC_CHECK = True
 """
 :var MIRAGE_PERIODIC_CHECK: This enables Mirage to periodically check metrics
     matching the namespaces in :mod:`settings.MIRAGE_PERIODIC_CHECK_NAMESPACES`
-    every :mod:`settings.MIRAGE_PERIODIC_CHECK_INTERVAL`.  Mirage should only
+    at every :mod:`settings.MIRAGE_PERIODIC_CHECK_INTERVAL`.  Mirage should only
     be configured to periodically analyse key metrics.  For further in depth
     details regarding Mirage periodic check and their impact, please see the
     Mirage Periodic Checks documentation at:
     https://earthgecko-skyline.readthedocs.io/en/latest/mirage.html#periodic-checks
+    Further :mod:`settings.MIRAGE_ONLY_METRICS` are handled by
 :vartype MIRAGE_PERIODIC_CHECK: boolean
 """
 
@@ -1546,6 +1547,18 @@ MIRAGE_PERIODIC_CHECK_NAMESPACES = [
     same way that :mod:`settings.SKIP_LIST` does, it matches in the string or
     the dotted namespace elements.
 :vartype MIRAGE_PERIODIC_CHECK_NAMESPACES: list
+"""
+
+MIRAGE_ALWAYS_METRICS = []
+"""
+:var MIRAGE_ALWAYS_METRICS: These are metrics you want to always be checked by
+    Mirage, every minute and not just by Analyzer.  For this to be in effect,
+    you must ensure that MIRAGE_PERIODIC_CHECK is set to ``True``.  This allows
+    for a use case where you want to apply a specific
+    :mod:`settings.CUSTOM_ALGORITHMS` algorithm on a metric, all the time.  The
+    metrics declared here must be absolute metric names, no element matching or
+    regex is applied.
+:vartype MIRAGE_ALWAYS_METRICS: list
 """
 
 MIRAGE_AUTOFILL_TOOSHORT = False


### PR DESCRIPTION
IssueID #3566: custom_algorithms

- Added settings.MIRAGE_ALWAYS_METRICS to allow for custom algorithms to be run
  on specified metrics on every run.

Modified:
docs/algorithms/custom-algorithms.rst
skyline/analyzer/analyzer.py
skyline/mirage/mirage_algorithms.py
skyline/settings.py