### PR TITLE
metric_flux_filled_key bug & remove entries from the current.anomalies

### DIFF
--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -766,12 +766,10 @@ CUSTOM_ALGORITHMS = {}
 
 """
 
-DEBUG_CUSTOM_ALGORITHMS = {}
+DEBUG_CUSTOM_ALGORITHMS = False
 """
-:var DEBUG_CUSTOM_ALGORITHMS: This is the number of algorithms that must return True before a
-    metric is classified as anomalous by Analyzer.  An empty dict {} disables
-    this feature.
-:vartype CUSTOM_ALGORITHMS: dict
+:var DEBUG_CUSTOM_ALGORITHMS: a boolean to enable debugging.
+:vartype DEBUG_CUSTOM_ALGORITHMS: boolean
 """
 
 RUN_OPTIMIZED_WORKFLOW = True


### PR DESCRIPTION
IssueID #3570: Mirage - populate_redis
IssueID #3306: Record anomaly_end_timestamp
IssueID #3566: custom_algorithms

- Defined metric_flux_filled_key bug outside original conditional block as there
  is now 3 conditions which can set sort_data and it fails to interpolate this
  variable sometimes when mirage_filled (3570)
- Remove entries from the current.anomalies set if the timestamp is older than
  FULL_DURATION (3306)
- Added some additional debug logging and corrected DEBUG_CUSTOM_ALGORITHMS
  docstring (3566)

Modified:
skyline/analyzer/analyzer.py
skyline/settings.py