### PR TITLE
Change all external alerter expiry key to id

### DIFF
--- a/skyline/analyzer/alerters.py
+++ b/skyline/analyzer/alerters.py
@@ -1995,6 +1995,19 @@ def alert_http(alert, metric, context):
                 value_str = str(metric[0])
             full_duration_str = str(int(full_duration))
             expiry_str = str(int(alert[2]))
+
+            # @added 20200624 - Feature #3560: External alert config
+            # Add the external alerter id to the metric_alert_dict
+            external_alerter_id = None
+            try:
+                if alert[4]['type'] == 'external':
+                    # @modified 20200624 - Feature #3560: External alert config
+                    # Set the alert key to the external alerter id
+                    # external_alerter_alerter = alert[4]['alerter']
+                    external_alerter_id = alert[4]['id'].replace('external-', '')
+            except:
+                external_alerter_id = None
+
             metric_alert_dict = {
                 "metric": str(metric[1]),
                 "timestamp": timestamp_str,
@@ -2002,7 +2015,8 @@ def alert_http(alert, metric, context):
                 "full_duration": full_duration_str,
                 "expiry": expiry_str,
                 "source": str(source),
-                "token": str(alerter_token)
+                "token": str(alerter_token),
+                "id": str(external_alerter_id)
             }
             # @modified 20200302: Feature #3396: http_alerter
             # Add the token as an independent entity from the alert

--- a/skyline/analyzer/analyzer.py
+++ b/skyline/analyzer/analyzer.py
@@ -3257,17 +3257,27 @@ class Analyzer(Thread):
                             analyzer_metric = True
 
                             # @added 20200610 - Feature #3560: External alert config
-                            external_alerter_alerter = None
+                            # @modified 20200624 - Feature #3560: External alert config
+                            # Set the alert key to the external alerter id
+                            # external_alerter_alerter = None
+                            external_alerter_id = None
                             try:
                                 if alert[4]['type'] == 'external':
-                                    external_alerter_alerter = alert[4]['alerter']
+                                    # @modified 20200624 - Feature #3560: External alert config
+                                    # Set the alert key to the external alerter id
+                                    # external_alerter_alerter = alert[4]['alerter']
+                                    external_alerter_id = alert[4]['id'].replace('external-', '')
                             except:
-                                pass
+                                external_alerter_id = None
 
                             # @modified 20200610 - Feature #3560: External alert config
                             # Use the all_alerts list which includes external alert configs
-                            if external_alerter_alerter:
-                                cache_key = 'last_alert.%s.%s.%s' % (str(external_alerter_alerter), alert[1], metric[1])
+                            # @modified 20200624 - Feature #3560: External alert config
+                            # Set the alert key to the external alerter id
+                            # if external_alerter_alerter:
+                            #     cache_key = 'last_alert.%s.%s.%s' % (str(external_alerter_alerter), alert[1], metric[1])
+                            if external_alerter_id:
+                                cache_key = 'last_alert.%s.%s.%s' % (str(external_alerter_id), alert[1], metric[1])
                             else:
                                 cache_key = 'last_alert.%s.%s' % (alert[1], metric[1])
                             if LOCAL_DEBUG:

--- a/skyline/mirage/mirage.py
+++ b/skyline/mirage/mirage.py
@@ -2139,18 +2139,28 @@ class Mirage(Thread):
                     if pattern_match:
 
                         # @added 20200610 - Feature #3560: External alert config
-                        external_alerter_alerter = None
+                        # @modified 20200624 - Feature #3560: External alert config
+                        # Set the alert key to the external alerter id
+                        # external_alerter_alerter = None
+                        external_alerter_id = None
                         try:
                             if alert[4]['type'] == 'external':
-                                external_alerter_alerter = alert[4]['alerter']
+                                # @modified 20200624 - Feature #3560: External alert config
+                                # Set the alert key to the external alerter id
+                                # external_alerter_alerter = alert[4]['alerter']
+                                external_alerter_id = alert[4]['id'].replace('external-', '')
                         except:
                             pass
 
                         # @modified 20200610 - Feature #3560: External alert config
                         # Use the all_alerts list which includes external alert configs
                         # cache_key = 'mirage.last_alert.%s.%s' % (alert[1], metric[1])
-                        if external_alerter_alerter:
-                            cache_key = 'mirage.last_alert.%s.%s.%s' % (str(external_alerter_alerter), alert[1], metric[1])
+                        # @modified 20200624 - Feature #3560: External alert config
+                        # Set the alert key to the external alerter id
+                        # if external_alerter_alerter:
+                        #     cache_key = 'mirage.last_alert.%s.%s.%s' % (str(external_alerter_alerter), alert[1], metric[1])
+                        if external_alerter_id:
+                            cache_key = 'mirage.last_alert.%s.%s.%s' % (str(external_alerter_id), alert[1], metric[1])
                         else:
                             cache_key = 'mirage.last_alert.%s.%s' % (alert[1], metric[1])
 

--- a/skyline/mirage/mirage_alerters.py
+++ b/skyline/mirage/mirage_alerters.py
@@ -1805,6 +1805,19 @@ def alert_http(alert, metric, second_order_resolution_seconds, context):
             value_str = str(float(metric[0]))
             full_duration_str = str(int(full_duration))
             expiry_str = str(int(alert[2]))
+
+            # @added 20200624 - Feature #3560: External alert config
+            # Add the external alerter id to the metric_alert_dict
+            external_alerter_id = None
+            try:
+                if alert[4]['type'] == 'external':
+                    # @modified 20200624 - Feature #3560: External alert config
+                    # Set the alert key to the external alerter id
+                    # external_alerter_alerter = alert[4]['alerter']
+                    external_alerter_id = alert[4]['id'].replace('external-', '')
+            except:
+                external_alerter_id = None
+
             metric_alert_dict = {
                 "metric": str(metric[1]),
                 "timestamp": timestamp_str,
@@ -1812,7 +1825,8 @@ def alert_http(alert, metric, second_order_resolution_seconds, context):
                 "full_duration": full_duration_str,
                 "expiry": expiry_str,
                 "source": str(source),
-                "token": str(alerter_token)
+                "token": str(alerter_token),
+                "id": str(external_alerter_id)
             }
             # @modified 20200302: Feature #3396: http_alerter
             # Add the token as an independent entity from the alert


### PR DESCRIPTION
IssueID #3560: External alert config

- Changed external alerter expiry key to the alerter id rather than the alerter,
  to send alerts for every defined external alerter rather than per alerter
- Added external alerter id to the alert json

Modified:
skyline/analyzer/alerters.py
skyline/analyzer/analyzer.py
skyline/mirage/mirage.py
skyline/mirage/mirage_alerters.py