### PR TITLE
alert pattern changes

### DIFF
--- a/docs/flux.rst
+++ b/docs/flux.rst
@@ -132,5 +132,5 @@ and services running:
   uploaded data.
 
 For specific details about the data formats and methods for uploading and
-processing data files see the `upload_data to Flux <uploa-data-to-flux.html>`__
+processing data files see the `upload_data to Flux <upload-data-to-flux.html>`__
 page.

--- a/docs/upload-data-to-flux.rst
+++ b/docs/upload-data-to-flux.rst
@@ -88,7 +88,23 @@ header row and rows to ignore.  A info file is used to inform Skyline how to
 read and metric the data, take 2020-05-16-11.device_id.012383.info.json
 Note, in processing rows are 0-indexed
 
-info.json
+Your mileage may vary on different date formats, use as acceptable pandas date
+formats.  Tested date formats known to work:
+
+::
+
+    16-05-2020 11:00     # %d-%m-%Y %H:%M
+    16-05-2020 11:00:00  # %d-%m-%Y %H:%M:%S
+    2020/05/16 11:00:00  # %Y/%m/%d %H:%M:%S
+
+Known incapable date format, this date format has failed to be interpreted as a
+date column in the ``pandas.to_datetime`` conversion:
+
+::
+
+    2020-05-16 11:00:00  # %d-%m-%Y %H:%M:%S
+
+**info.json**
 
 ::
 


### PR DESCRIPTION
IssueID #3586: Change all alert pattern checks to matched_or_regexed_in_list
IssueID #3594: Add timestamp to ENABLE_BOUNDARY_DEBUG output

- Changed original alert matching pattern to use new matched_or_regexed_in_list
  function
- Add timestamp to ENABLE_BOUNDARY_DEBUG output
- Update flux docs

Modified:
docs/flux.rst
docs/upload-data-to-flux.rst
skyline/boundary/boundary.py
skyline/boundary/boundary_algorithms.py