### PR TITLE
Handle multiple metrics in base_name conversion

### DIFF
--- a/skyline/analyzer/alerters.py
+++ b/skyline/analyzer/alerters.py
@@ -154,7 +154,15 @@ def alert_smtp(alert, metric, context):
 
     # @added 20161229 - Feature #1830: Ionosphere alerts
     # Added Ionosphere variables
-    base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+
+    # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+    # base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+    metric_name = str(metric[1])
+    if metric_name.startswith(settings.FULL_NAMESPACE):
+        base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+    else:
+        base_name = metric_name
+
     # @modified 20190520 - Branch #3002: docker
     # wix-playground added a hashlib hexdigest method which has not been
     # verified so using the originaly method useless the base_name is longer
@@ -1412,7 +1420,15 @@ def alert_slack(alert, metric, context):
     import simplejson as json
 
     logger.info('alert_slack - anomalous metric :: alert: %s, metric: %s' % (str(alert), str(metric)))
-    base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+
+    # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+    # base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+    metric_name = str(metric[1])
+    if metric_name.startswith(settings.FULL_NAMESPACE):
+        base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+    else:
+        base_name = metric_name
+
     # @modified 20190520 - Branch #3002: docker
     # wix-playground added a hashlib hexdigest method which has not been
     # verified so using the original method useless the base_name is longer

--- a/skyline/luminosity/process_correlations.py
+++ b/skyline/luminosity/process_correlations.py
@@ -310,7 +310,13 @@ def get_assigned_metrics(i, base_name):
         if not correlate_namespace_to:
             correlate_with_metrics = []
             for metric_name in unique_metrics:
-                metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+                # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+                # metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+                if metric_name.startswith(settings.FULL_NAMESPACE):
+                    metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+                else:
+                    metric_base_name = metric_name
+
                 add_metric, add_metric_matched_by = matched_or_regexed_in_list(skyline_app, metric_base_name, correlate_namespaces_only)
                 if not add_metric:
                     correlate_with_metrics.append(metric_name)
@@ -323,7 +329,13 @@ def get_assigned_metrics(i, base_name):
         correlate_with_namespace = correlate_namespace_matched_by['matched_namespace']
         if correlate_with_namespace:
             for metric_name in unique_metrics:
-                metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+                # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+                # metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+                if metric_name.startswith(settings.FULL_NAMESPACE):
+                    metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+                else:
+                    metric_base_name = metric_name
+
                 add_metric, add_metric_matched_by = matched_or_regexed_in_list(skyline_app, metric_base_name, [correlate_with_namespace])
                 if add_metric:
                     correlate_with_metrics.append(metric_name)
@@ -500,7 +512,13 @@ def get_correlations(
         # if count > 1000:
         #     break
         correlated = None
-        metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+        # metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        if metric_name.startswith(settings.FULL_NAMESPACE):
+            metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        else:
+            metric_base_name = metric_name
+
         if str(metric_base_name) == str(base_name):
             continue
         try:
@@ -607,7 +625,13 @@ def get_correlations(
         remote_metrics_count += 1
         correlated = None
         metric_name = str(ts_data[0])
-        metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+        # metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        if metric_name.startswith(settings.FULL_NAMESPACE):
+            metric_base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        else:
+            metric_base_name = metric_name
+
         if str(metric_base_name) == str(base_name):
             continue
         timeseries = []

--- a/skyline/mirage/mirage_alerters.py
+++ b/skyline/mirage/mirage_alerters.py
@@ -163,7 +163,15 @@ def alert_smtp(alert, metric, second_order_resolution_seconds, context):
 
     # @added 20161229 - Feature #1830: Ionosphere alerts
     # Added Ionosphere variables
-    base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+
+    # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+    # base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+    metric_name = str(metric[1])
+    if metric_name.startswith(settings.FULL_NAMESPACE):
+        base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+    else:
+        base_name = metric_name
+
     # @modified 20191008 - Branch #3002: docker
     # wix-playground added a hashlib hexdigest method which has not been
     # verified so using the originaly method useless the base_name is longer
@@ -1252,7 +1260,15 @@ def alert_slack(alert, metric, second_order_resolution_seconds, context):
     import simplejson as json
 
     logger.info('alert_slack - anomalous metric :: alert: %s, metric: %s' % (str(alert), str(metric)))
-    base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+
+    # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+    # base_name = str(metric[1]).replace(settings.FULL_NAMESPACE, '', 1)
+    metric_name = str(metric[1])
+    if metric_name.startswith(settings.FULL_NAMESPACE):
+        base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+    else:
+        base_name = metric_name
+
     # @modified 20191008 - Branch #3002: docker
     # wix-playground added a hashlib hexdigest method which has not been
     # verified so using the original method useless the base_name is longer

--- a/skyline/panorama/panorama.py
+++ b/skyline/panorama/panorama.py
@@ -1662,7 +1662,13 @@ class Panorama(Thread):
                                 for unique_metric in unique_metrics:
                                     if unique_metric not in db_fullnamespace_unique_metrics:
                                         try:
-                                            base_name = unique_metric.replace(settings.FULL_NAMESPACE, '', 1)
+                                            # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+                                            # base_name = unique_metric.replace(settings.FULL_NAMESPACE, '', 1)
+                                            if unique_metric.startswith(settings.FULL_NAMESPACE):
+                                                base_name = unique_metric.replace(settings.FULL_NAMESPACE, '', 1)
+                                            else:
+                                                base_name = unique_metric
+
                                             metric_id = self.insert_new_metric(base_name)
                                             logger.info('inserted %s into metrics table, assigned id %s' % (base_name, str(metric_id)))
                                         except:

--- a/skyline/webapp/backend.py
+++ b/skyline/webapp/backend.py
@@ -566,7 +566,13 @@ def luminosity_remote_data(anomaly_timestamp):
             del original_timeseries
 
         # Convert the time series if this is a known_derivative_metric
-        base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
+        # base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        if metric_name.startswith(settings.FULL_NAMESPACE):
+            base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+        else:
+            base_name = metric_name
+
         known_derivative_metric = is_derivative_metric('webapp', base_name)
         if known_derivative_metric:
             try:


### PR DESCRIPTION
IssueID #3652: Handle multiple metrics in base_name conversion

Modified:
skyline/analyzer/alerters.py
skyline/mirage/mirage_alerters.py
skyline/luminosity/process_correlations.py
skyline/panorama/panorama.py
skyline/webapp/backend.py