### PR TITLE
ROOMBA_DO_NOT_PROCESS_BATCH_METRICS

### DIFF
--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -1249,6 +1249,17 @@ stall, I/O wait being one such edge case.  Although 99.999% of the time Roomba
 is fine, this ensures that no Roombas hang around longer than expected.
 """
 
+ROOMBA_DO_NOT_PROCESS_BATCH_METRICS = False
+"""
+:var ROOMBA_DO_NOT_PROCESS_BATCH_METRICS: Whether Horizon roomba should
+    euthanize batch processing metrics.
+:vartype ROOMBA_TIMEOUT: boolean
+
+This should be left as False unless you are backfilling batch metrics and do not
+want roomba removing data points before analyzer_batch has analyzed them.  If
+this is set to True, analyzer_batch euthanizes batch metrics.
+"""
+
 MAX_RESOLUTION = 1000
 """
 :var MAX_RESOLUTION: The Horizon agent will ignore incoming datapoints if their
@@ -2429,6 +2440,15 @@ IONOSPHERE_AUTOBUILD = True
     matched by age, etc or all and still be able to surface the available features
     profile page data on-demand.  NOT IMPLEMENTED YET
 
+"""
+
+IONOSPHERE_UNTRAINABLES = []
+"""
+:var IONOSPHERE_UNTRAINABLES: a list of metric names or namespaces that should
+    be deemed as untrainable.  For example you do not want to allow
+    http.status.500 to be trained that an occassional 1 or 2 errors is normal
+    and can be expected.
+:vartype IONOSPHERE_UNTRAINABLES: list
 """
 
 MEMCACHE_ENABLED = False


### PR DESCRIPTION
IssueID #3650: ROOMBA_DO_NOT_PROCESS_BATCH_METRICS
IssueID #3480: batch_processing
IssueID #3486: analyzer_batch
IssueID #3652: Handle multiple metrics in base_name conversion

- Added ROOMBA_DO_NOT_PROCESS_BATCH_METRICS to horizon/roomba.py, settings.py
  and analyzer/analyzer_batch.py to allow analyzer_batch to allow for roomba.py
  to not remove data points before analyzer_batch has analyzed them and enable
  analyzer_batch to euthanize the batch metric keys.
- In analyzer_batch if multiple work items exist and the timestamp in the work
  item is older than the last analyzed timestamp reported by Redis key, just
  skip and remove the work item.
- Euthanize keys if not done in roomba, allows for backfill processing via
  analyzer_batch
- Handle multiple metrics in base_name conversion in analyzer_batch
- Only log on the last data point, not on all but report a not_anomalous_count
  in analyzer_batch
- In analyzer_batch if multiple work items exist sort them by oldest timestamp
  and process the item with the oldest timestamp first

Modified:
skyline/analyzer/analyzer_batch.py
skyline/horizon/roomba.py
skyline/settings.py