### PR TITLE
webapp optimisation and crucible_process_training_data

### DIFF
--- a/skyline/webapp/crucible_backend.py
+++ b/skyline/webapp/crucible_backend.py
@@ -63,7 +63,13 @@ def engine_disposal(engine):
 # @modified 20200422 - Feature #3500: webapp - crucible_process_metrics
 #                      Feature #1448: Crucible web UI
 # Added pad_timeseries
-def submit_crucible_job(from_timestamp, until_timestamp, metrics_list, namespaces_list, source, alert_interval, user_id, user, add_to_panorama, pad_timeseries):
+# @added 20200607 - Feature #3630: webapp - crucible_process_training_data
+# Added training_data_json
+# def submit_crucible_job(from_timestamp, until_timestamp, metrics_list, namespaces_list, source, alert_interval, user_id, user, add_to_panorama, pad_timeseries, training_data_json):
+def submit_crucible_job(
+        from_timestamp, until_timestamp, metrics_list, namespaces_list, source,
+        alert_interval, user_id, user, add_to_panorama, pad_timeseries,
+        training_data_json):
     """
     Get a list of all the metrics passed and generate Crucible check files for
     each
@@ -80,6 +86,8 @@ def submit_crucible_job(from_timestamp, until_timestamp, metrics_list, namespace
     :param add_to_panorama: whether Crucible should add Skyline CONSENSUS
         anomalies to Panorama
     :param pad_timeseries: the amount of data to pad the time series with
+    :param training_data_json: the full path to the training_data json file if
+        source is training_data
     :type from_timestamp: int
     :type until_timestamp: int
     :type metrics_list: list
@@ -90,6 +98,7 @@ def submit_crucible_job(from_timestamp, until_timestamp, metrics_list, namespace
     :type user: str
     :type add_to_panorama: boolean
     :type pad_timeseries: str
+    :type training_data_json: str
     :return: tuple of lists
     :rtype:  (list, list, list, list)
 
@@ -254,6 +263,8 @@ def submit_crucible_job(from_timestamp, until_timestamp, metrics_list, namespace
         # @modified 20200421 - Feature #3500: webapp - crucible_process_metrics
         #                      Feature #1448: Crucible web UI
         # Added add_to_panorama
+        # @added 20200607 - Feature #3630: webapp - crucible_process_training_data
+        # Added training_data_json
         crucible_anomaly_data = 'metric = \'%s\'\n' \
                                 'value = \'%s\'\n' \
                                 'from_timestamp = \'%s\'\n' \
@@ -268,11 +279,12 @@ def submit_crucible_job(from_timestamp, until_timestamp, metrics_list, namespace
                                 'graphite_override_uri_parameters = \'%s\'\n' \
                                 'alert_interval = \'%s\'\n' \
                                 'add_to_panorama = %s\n' \
+                                'training_data_json = %s\n' \
             % (base_name, str(datapoint), str(from_timestamp),
                str(until_timestamp), str(settings.ALGORITHMS),
                triggered_algorithms, crucible_anomaly_dir, str(graphite_metric),
                skyline_app, str(added_at), str(graphite_override_uri_parameters),
-               str(alert_interval), str(add_to_panorama))
+               str(alert_interval), str(add_to_panorama), str(training_data_json))
 
         # Create an anomaly file with details about the anomaly
         crucible_anomaly_file = '%s/%s.txt' % (crucible_anomaly_dir, sane_metricname)

--- a/skyline/webapp/templates/crucible_process_metrics.html
+++ b/skyline/webapp/templates/crucible_process_metrics.html
@@ -9,6 +9,26 @@
 <code> message </code>: {{ display_message }}<br>
 {% endif %}
 
+<script>
+function validate_to_process_submission()
+{
+    var source = document.forms["process_metrics"]["source"];
+    var training_data_json = document.forms["process_metrics"]["training_data_json"];
+    if (source.value == "training_data") and (training_data_json.value == "")
+    {
+        window.alert("Please enter the training_data json file");
+        training_data_json.focus();
+        return false;
+    }
+    if (source.value == "training_data") and (add_to_panaroma.value == "true")
+    {
+        window.alert("You cannot add anomalies from training data to Panorama");
+        add_to_panaroma.focus();
+        return false;
+    }
+    return true;
+}</script>
+
 <div class="navbar-header" role="navigation">
   <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
     <span class="sr-only">Toggle navigation</span>
@@ -54,7 +74,7 @@
         <button type="button" class="btn btn-info" data-toggle="collapse" data-target="#process_options">Show process options</button>
         <div id="process_options" class="collapse">
   {% endif %}
-        <form action="crucible">
+        <form name="process_metrics" action="crucible" onsubmit="return validate_to_process_submission()">
   		  <table class="table table-hover">
   		    <thead>
   		      <tr>
@@ -114,7 +134,13 @@
 # Graphite is the only option currently
                 <option value="redis">redis</option>
 -->
+<!--          # @added 20200607 - Feature #3630: webapp - crucible_process_training_data -->
+                <option value="training_data">training_data</option>
               </select></td>
+  		      </tr>
+  		      <tr>
+  		        <td>training_data_json</td>
+  		        <td><input type="text" name="training_data_json" value="" /> the full path to training_data or saved trianing data json, if data_source is set to training_data</td>
   		      </tr>
   		      <tr>
                 <td>alert interval</td>

--- a/skyline/webapp/templates/features_profiles.html
+++ b/skyline/webapp/templates/features_profiles.html
@@ -928,7 +928,9 @@ Image file: {{ image }}<br><br>
       <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span></span> <span class="sky">json available [['app', '{{ app_context }}'], ['full_duration', {{ ts_full_duration }}]]</span></h4>
       {{ last_ts_json }}
  -->
-      <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span> <span class="sky">json available [['app', '{{ app_context }}'], ['full_duration', {{ ts_full_duration }}]] - last 30 data points</span></h4>
+<!-- # @modified 20200711 - Feature #3634: webapp - ionosphere - report number of data points
+     # Added length -->
+      <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span> <span class="sky">json available [['app', '{{ app_context }}'], ['full_duration', {{ ts_full_duration }}]] - last 30 data points of {{ anomalous_timeseries_length }}</span></h4>
       {{ last_ts_json[-30:] }}
 <!-- # @added 20170309 - Feature #1960: ionosphere_layers
 Also return the Analyzer FULL_DURATION timeseries if available in a Mirage
@@ -939,7 +941,9 @@ based features profile -->
       <h4><span class="logo"><span class="sky">Timeseries ::</span> <span class="re">anomalous ::</span></span></span> <span class="sky">json available [['app', 'Analyzer'], ['full_duration', {{ baseline_fd }}]]</span></h4>
       {{ last_i_ts_json }}
 -->
-      <h4><span class="logo"><span class="sky">Timeseries ::</span> <span class="re">anomalous ::</span></span> <span class="sky">json available [['app', 'Analyzer'], ['full_duration', {{ baseline_fd }}]] - last 30 data points</span></h4>
+<!-- # @modified 20200711 - Feature #3634: webapp - ionosphere - report number of data points
+     # Added length -->
+      <h4><span class="logo"><span class="sky">Timeseries ::</span> <span class="re">anomalous ::</span></span> <span class="sky">json available [['app', 'Analyzer'], ['full_duration', {{ baseline_fd }}]] - last 30 data points of {{ ts_json_length }}</span></h4>
       {{ last_i_ts_json[-30:] }}
     {% endif %}
   {% endif %}

--- a/skyline/webapp/templates/training_data.html
+++ b/skyline/webapp/templates/training_data.html
@@ -844,13 +844,17 @@ Image file: {{ image }}<br><br>
 <!-- # @modified 20170309 - Feature #1960: ionosphere_layers
     <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">not anomalous ::</span></span></span> <span class="sky">available</span></h4>
       {{ timeseries[-30:] }}-->
-    <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span></span> <span class="sky">json available [['app', '{{ app_context }}'], ['full_duration', {{ ts_full_duration }}]] - last 30 data points</span></h4>
+<!-- # @modified 20200711 - Feature #3634: webapp - ionosphere - report number of data points
+     # Added length -->
+    <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span></span> <span class="sky">json available [['app', '{{ app_context }}'], ['full_duration', {{ ts_full_duration }}]] - last 30 data points of {{ anomalous_timeseries_length }}</span></h4>
       {{ last_ts_json[-30:] }}
 <!-- # @added 20170309 - Feature #1960: ionosphere_layers
 Also return the Analyzer FULL_DURATION timeseries if available in a Mirage
 based features profile -->
     {% if ionosphere_json %}
-    <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span></span> <span class="sky">json available [['app', 'Analyzer'], ['full_duration', {{ baseline_fd }}]] - last 30 data points</span></h4>
+<!-- # @modified 20200711 - Feature #3634: webapp - ionosphere - report number of data points
+     # Added length -->
+    <h4><span class="logo"><span class="sky">Time series ::</span> <span class="re">anomalous ::</span></span></span> <span class="sky">json available [['app', 'Analyzer'], ['full_duration', {{ baseline_fd }}]] - last 30 data points of {{ ts_json_length }}</span></h4>
 <!--      {{ ionosphere_json[-30:] }} -->
       {{ last_i_ts_json[-30:] }}
     {% endif %}


### PR DESCRIPTION
IssueID #3464: Optimise ionosphere_backend ionosphere_search queries
IssueID #3648: webapp - fp_search - do not use Redis metric check
IssueID #3630: webapp - crucible_process_training_data
IssueID #3634: webapp - ionosphere - report number of data points
IssueID #3652: Handle multiple metrics in base_name conversion
IssueID #1996: Ionosphere - matches page

Modified:
skyline/webapp/crucible_backend.py
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/crucible_process_metrics.html
skyline/webapp/templates/features_profiles.html
skyline/webapp/templates/training_data.html
skyline/webapp/webapp.py