### PR TITLE
IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE

### DIFF
--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -2152,6 +2152,20 @@ IONOSPHERE_MANAGE_PURGE = True
 :vartype IONOSPHERE_MANAGE_PURGE: boolean
 """
 
+IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = False
+"""
+:var IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE: By defualt Graphite NOW graphs in
+    training_data are retrieved from Graphite when the training data is viewed.
+    Graphite NOW graphs are then generated using the current timestamp and
+    plotting graphs at now - 7h, now - 24h, now - 7days and now - 30days, this
+    can cause the actual anomalous period to not be shown in the Graphite NOW
+    graphs if the training data is only loaded days later.  This is especially
+    true if metrics are batch processed with historic data.  If this settings is
+    set to True, Graphite NOW graphs will be loaded as Graphite THEN graphs,
+    using the anomaly timestamp as now.
+:vartype IONOSPHERE_GRAPHITE_NOW_OVERRIDE: boolean
+"""
+
 SKYLINE_URL = 'https://skyline.example.com'
 """
 :var SKYLINE_URL: The http or https URL (and port if required) to access your

--- a/skyline/skyline_functions.py
+++ b/skyline/skyline_functions.py
@@ -55,6 +55,12 @@ try:
 except:
     skyline_metrics_carbon_port = CARBON_PORT
 
+# @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+try:
+    IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = settings.IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+except:
+    IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = False
+
 config = {'user': settings.PANORAMA_DBUSER,
           'password': settings.PANORAMA_DBUSERPASS,
           'host': settings.PANORAMA_DBHOST,
@@ -794,7 +800,11 @@ def get_graphite_metric(
                     str_value = str(int(int_hours) / 24)
                     period = 'days'
                 if 'graphite_now' in output_object:
-                    unencoded_graph_title = 'Graphite NOW at %s %s' % (str_value, period)
+                    # @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+                    if IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE:
+                        unencoded_graph_title = 'Graphite THEN at %s %s' % (str_value, period)
+                    else:
+                        unencoded_graph_title = 'Graphite NOW at %s %s' % (str_value, period)
                 # @added 20170308 - Feature #1960: ionosphere_layers
                 matched_graph = False
                 if 'matched.fp_id' in output_object:

--- a/skyline/webapp/ionosphere_backend.py
+++ b/skyline/webapp/ionosphere_backend.py
@@ -113,6 +113,12 @@ except:
 if overall_verify_ssl:
     logging.captureWarnings(True)
 
+# @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+try:
+    IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = settings.IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+except:
+    IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = False
+
 
 def ionosphere_get_metrics_dir(requested_timestamp, context):
     """
@@ -800,6 +806,12 @@ def ionosphere_metric_data(requested_timestamp, data_for_metric, context, fp_id)
     # operator about the metric.
     graphite_now_images = []
     graphite_now = int(time.time())
+
+    # @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+    # Allow to override the Graphite NOW graphs with Graphite THEN graphs
+    if IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE:
+        graphite_now = int(requested_timestamp)
+
     graph_resolutions = []
     # @modified 20170116 - Feature #1854: Ionosphere learn - generations
     #                      Feature #1842: Ionosphere - Graphite now graphs

--- a/skyline/webapp/templates/training_data.html
+++ b/skyline/webapp/templates/training_data.html
@@ -755,13 +755,13 @@ Image file: {{ image }}<br><br>
   {% endif %}
 
   {% if fp_id_matched %}
-      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs NOW ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong> when <strong><a href="?fp_view=true&fp_id={{ fp_id_matched }}&metric={{ for_metric }}">fp_id {{ fp_id_matched }}</a> <font color="green">MATCHED</font></strong></h4>
+      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs {{ graphite_now_graphs_title }} ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong> when <strong><a href="?fp_view=true&fp_id={{ fp_id_matched }}&metric={{ for_metric }}">fp_id {{ fp_id_matched }}</a> <font color="green">MATCHED</font></strong></h4>
   {% elif layers_id_matched %}
-      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs NOW ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong> when <strong>layers id {{ layers_id_matched }} <font color="green">MATCHED</font></strong></h4>
+      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs {{ graphite_now_graphs_title }} ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong> when <strong>layers id {{ layers_id_matched }} <font color="green">MATCHED</font></strong></h4>
   {% elif saved_metric_td_requested %}
-      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs when saved ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong></h4>
+      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs when saved as {{ graphite_now_graphs_title }} ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong></h4>
   {% else %}
-      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs NOW ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong></h4>
+      <h4><span class="logo"><span class="sky">Graphite ::</span> <span class="re">graphs {{ graphite_now_graphs_title }} ::</span></span></span> at <strong>7h, 24h, 7d and 30d</strong> for anomaly at <strong>{{ human_date }}</strong></h4>
   {% endif %}
 <!-- @added 20170106 - Feature #1842: Ionosphere - Graphite now graphs -->
   {% for gimage in graphite_now_images %}

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -301,6 +301,12 @@ try:
 except:
     GRAPHITE_RENDER_URI = 'render'
 
+# @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+try:
+    IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = settings.IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+except:
+    IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = False
+
 
 @app.before_request
 # def setup_logging():
@@ -4582,6 +4588,11 @@ def ionosphere():
                             data_dict = {"status": {"created": "already exists"}, "data": {"fp_id": fp_id}}
                     return jsonify(data_dict), 200
 
+            # @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+            graphite_now_graphs_title = 'NOW'
+            if IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE:
+                graphite_now_graphs_title = 'THEN'
+
             return render_template(
                 'ionosphere.html', timestamp=requested_timestamp,
                 for_metric=base_name, metric_vars=m_vars, metric_files=mpaths,
@@ -4664,6 +4675,8 @@ def ionosphere():
                 # @added 20200711 - Feature #3634: webapp - ionosphere - report number of data points
                 ts_json_length=ts_json_length,
                 anomalous_timeseries_length=anomalous_timeseries_length,
+                # @added 20200731 - Feature #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE
+                graphite_now_graphs_title=graphite_now_graphs_title,
                 version=skyline_version, duration=(time.time() - start),
                 print_debug=debug_on), 200
         except:


### PR DESCRIPTION
IssueID #3654: IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE

- Allow to override the Graphite NOW graphs with Graphite THEN graphs

Modified:
skyline/settings.py
skyline/skyline_functions.py
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/training_data.html
skyline/webapp/webapp.py