### PR TITLE
IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR

### DIFF
--- a/docs/SNAB.rst
+++ b/docs/SNAB.rst
@@ -1,0 +1,14 @@
+SNAB
+====
+
+SNAB is for algorithm testing and benchmarking for real time data and historical
+data.
+
+SNAB was inspired by the The Numenta Anomaly Benchmark project (https://github.com/numenta/NAB)
+and attempts to provide a framework within Skyline to test and benchmark on
+both real time and historical static data with any algorithms.
+
+SNAB is not a replacement for NAB, it is simply a NAB like implementation that
+suits Skyline.  SNAB is looser in its requirements for algorithms and removes
+the O(N) time complexity requirement that NAB has and can also use algorithms
+that batch process.

--- a/docs/ionosphere.rst
+++ b/docs/ionosphere.rst
@@ -871,6 +871,20 @@ MySQL configuration
 There could be a lot of tables. **DEFINITELY** implement ``innodb_file_per_table``
 in MySQL.
 
+IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+----------------------------------------------
+
+Enabling :mod:`settings.IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR` allows
+you to not remove training data when it is :mod:`settings.IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR`
+seconds old.  Instead for any training data for metrics that match a namespace
+substring declared in the :mod:`settings.IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR`
+list will be moved to :mod:`settings.IONOSPHERE_HISTORICAL_DATA_FOLDER`
+This is an advance feature and not for general purpose, please read the
+documentation in the docstrings for more info, see:
+:mod:`settings.IONOSPHERE_HISTORICAL_DATA_FOLDER` and
+:mod:`settings.IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR`
+
+
 Ionosphere - autobuild features_profiles dir
 --------------------------------------------
 

--- a/skyline/ionosphere/agent.py
+++ b/skyline/ionosphere/agent.py
@@ -80,7 +80,9 @@ class IonosphereAgent():
             sleep(100)
 
             # Clean up old timeseries data files and folders
-            self.purge_old_data_dirs(settings.IONOSPHERE_DATA_FOLDER, settings.IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR)
+            # @modified 20200813 - Feature #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+            # Do not clean up and purge data on start up
+            # self.purge_old_data_dirs(settings.IONOSPHERE_DATA_FOLDER, settings.IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR)
 
 
 if __name__ == "__main__":

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -2105,8 +2105,22 @@ ENABLE_IONOSPHERE_DEBUG = False
 IONOSPHERE_DATA_FOLDER = '/opt/skyline/ionosphere/data'
 """
 :var IONOSPHERE_DATA_FOLDER: This is the path for the Ionosphere data folder
-    where anomaly data for timeseries will be stored - absolute path
+    where anomaly data for timeseries and training will be stored - absolute path
 :vartype IONOSPHERE_DATA_FOLDER: str
+"""
+
+IONOSPHERE_HISTORICAL_DATA_FOLDER = '/opt/skyline/ionosphere/historical_data'
+"""
+:var IONOSPHERE_HISTORICAL_DATA_FOLDER: The absolute path for the Ionosphere
+    historical data folder where anomaly data for timeseries and training will
+    moved to when it reaches it purge age as defined for the namespace in
+    :mod:`settings.IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR`. Unless you
+    are feeding in and analysing historical data, this can generally be ignored
+    and is an advanced setting.  Note if you do use this and
+    :mod:`settings.IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR` be advised
+    that there is NO purge of this directory, it must be done MANUALLY when
+    you have completed your historical analysis and training.
+:vartype IONOSPHERE_HISTORICAL_DATA_FOLDER: str
 """
 
 IONOSPHERE_PROFILES_FOLDER = '/opt/skyline/ionosphere/features_profiles'
@@ -2136,8 +2150,20 @@ IONOSPHERE_CHECK_MAX_AGE = 300
 IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR = 86400
 """
 :var IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR: Ionosphere will keep timeseries
-    data files for this long, for the operator to review.
+    data files for this long, for the operator to review and train on.
 :vartype IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR: int
+"""
+
+IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR = []
+"""
+:var IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR: After :mod:`settings.IONOSPHERE_KEEP_TRAINING_TIMESERIES_FOR`
+    has elapsed Ionosphere will move training data for metric namespaces declared
+    in this list to the :mod:`settings.ONOSPHERE_HISTORICAL_DATA_FOLDER`. The
+    metric namespaces defined here are only matched on a simple substring match,
+    NOT on elements and/or a regex.  If the substring is in the metric name
+    it will be moved.  Unless you are feeding in and analysed historical data,
+    this can generally be ignored and is an advanced setting.
+:vartype IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR: list
 """
 
 IONOSPHERE_MANAGE_PURGE = True

--- a/skyline/skyline_functions.py
+++ b/skyline/skyline_functions.py
@@ -61,6 +61,16 @@ try:
 except:
     IONOSPHERE_GRAPHITE_NOW_GRAPHS_OVERRIDE = False
 
+# @added 20200813 - Feature #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+try:
+    IONOSPHERE_HISTORICAL_DATA_FOLDER = settings.IONOSPHERE_HISTORICAL_DATA_FOLDER
+except:
+    IONOSPHERE_HISTORICAL_DATA_FOLDER = '/opt/skyline/ionosphere/historical_data'
+try:
+    IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR = settings.IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+except:
+    IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR = []
+
 config = {'user': settings.PANORAMA_DBUSER,
           'password': settings.PANORAMA_DBUSERPASS,
           'host': settings.PANORAMA_DBHOST,
@@ -2151,3 +2161,47 @@ def sort_timeseries(timeseries):
         del timeseries
 
     return sorted_timeseries
+
+
+# @added 20200813 - Feature #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+def historical_data_dir_exists(current_skyline_app, ionosphere_data_dir):
+    """
+    This function is used to determine if an ionosphere data dir exists and if
+    it does return the path.
+    """
+    current_skyline_app_logger = str(current_skyline_app) + 'Log'
+    current_logger = logging.getLogger(current_skyline_app_logger)
+
+    historical_data_path_exists = False
+    if os.path.exists(ionosphere_data_dir):
+        current_logger.info('%s :: historical_data_dir_exists :: ionosphere_data_dir exists - %s' % (
+            current_skyline_app, ionosphere_data_dir))
+        return (historical_data_path_exists, ionosphere_data_dir)
+    else:
+        current_logger.info('%s :: historical_data_dir_exists :: ionosphere_data_dir does not exist - %s' % (
+            current_skyline_app, ionosphere_data_dir))
+
+    # @added 20200813 - Feature #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+    try:
+        IONOSPHERE_HISTORICAL_DATA_FOLDER = settings.IONOSPHERE_HISTORICAL_DATA_FOLDER
+    except:
+        IONOSPHERE_HISTORICAL_DATA_FOLDER = '/opt/skyline/ionosphere/historical_data'
+    try:
+        IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR = settings.IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
+    except:
+        IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR = []
+
+    if IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR:
+        current_logger.info('%s :: historical_data_dir_exists :: checking for any IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR namespaces match in %s' % (
+            current_skyline_app, ionosphere_data_dir))
+        historical_data_dir = ionosphere_data_dir.replace(settings.IONOSPHERE_DATA_FOLDER, IONOSPHERE_HISTORICAL_DATA_FOLDER)
+        if os.path.exists(historical_data_dir):
+            historical_data_path_exists = True
+            current_logger.info('%s :: historical_data_dir_exists :: historical_data_dir exists - %s' % (
+                current_skyline_app, historical_data_dir))
+        else:
+            current_logger.info('%s :: historical_data_dir_exists :: historical_data_dir does not exist - %s' % (
+                current_skyline_app, historical_data_dir))
+        if historical_data_path_exists:
+            ionosphere_data_dir = historical_data_dir
+    return (historical_data_path_exists, ionosphere_data_dir)

--- a/skyline/webapp/templates/training_data.html
+++ b/skyline/webapp/templates/training_data.html
@@ -236,6 +236,10 @@ Also note:
 # Allow the operator to save a training_data set -->
     {% if saved_metric_td == False %}
     <h4><span class="logo"><span class="sky">Training ::</span> <span class="re">data :: </span>{{ for_metric }} - {{ human_date }}</h4>
+<!-- # @added 20200813 - Feature #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR -->
+      {% if historical_training_data == True %}
+    <center><h4><span class="logo"><span class="sky"></span> <span class="re">This is HISTORICAL training data</span></span></h4></center>
+      {% endif %}
     {% else %}
     <h4><span class="logo"><span class="re">SAVED - </span><span class="sky">Training ::</span> <span class="re">data :: </span>{{ for_metric }} - {{ human_date }}</h4>
     {% endif %}


### PR DESCRIPTION
IssueID #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR

- Allowing training data to be kept indefinitely for certain metrics and to
  train from this historical training data
- Added related settings of IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR and
  IONOSPHERE_HISTORICAL_DATA_FOLDER
- Ammend ionosphere to add historical training data to the ionosphere.training_data
  Redis set
- Handle historical training data in the webapp

Modified:
docs/ionosphere.rst
skyline/features_profile.py
skyline/ionosphere/agent.py
skyline/ionosphere/ionosphere.py
skyline/ionosphere_functions.py
skyline/settings.py
skyline/skyline_functions.py
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/training_data.html
skyline/webapp/webapp.py