### PR TITLE
flux - POST multiple metrics

### DIFF
--- a/docs/flux.rst
+++ b/docs/flux.rst
@@ -28,8 +28,11 @@ Redis key, flux discards the data.
 POST request
 ------------
 
-The POST endpoint is `/flux/metric_data_post` and this accepts JSON data.
-Here is an example of the data it requires and an example POST request.
+The POST endpoint is `/flux/metric_data_post` and this accepts JSON data.  The
+json can have data for a single metric or for multiple metrics in a single POST.
+
+Here is an example of the data a sinlge metric POST requires and an example POST
+request.
 
 .. code-block:: json
 
@@ -43,6 +46,34 @@ Here is an example of the data it requires and an example POST request.
 .. code-block:: bash
 
   curl -vvv -u username:password -d '{"metric":"vista.nodes.skyline-1.cpu.user","timestamp":"1478021700","value":"1.0","key":"YOURown32charSkylineAPIkeySecret"}' -H "Content-Type: application/json" -X POST https://skyline.example.org/flux/metric_data_post
+
+Here is an example of the data a multiple metrics POST requires and an example
+POST request for multiple metrics:
+
+.. warning:: When submitting mulitple metrics in a POST, if any one element of
+  any metric is not valid the entire POST will be rejected.
+
+.. code-block:: json
+
+  {
+  	"key": "YOURown32charSkylineAPIkeySecret"
+    "metrics": [
+      {
+      	"metric": "vista.nodes.skyline-1.cpu.user",
+      	"timestamp": "1478021700",
+      	"value": "1.0",
+      },
+      {
+      	"metric": "vista.nodes.skyline-1.cpu.system",
+      	"timestamp": "1478021700",
+      	"value": "0.2",
+      }
+    ]
+  }
+
+.. code-block:: bash
+
+  curl -vvv -u username:password -d '{"key":"YOURown32charSkylineAPIkeySecret","metrics":[{"metric":"vista.nodes.skyline-1.cpu.user","timestamp":"1478021700","value":"1.0"},{"metric":"vista.nodes.skyline-1.cpu.system","timestamp":"1478021700","value":"0.2"}]}' -H "Content-Type: application/json" -X POST https://skyline.example.org/flux/metric_data_post
 
 GET request
 -----------

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -2700,6 +2700,27 @@ FLUX_SELF_API_KEY = 'YOURown32charSkylineAPIkeySecret'
 :vartype FLUX_SELF_API_KEY: str
 """
 
+FLUX_API_KEYS = {}
+"""
+:var FLUX_API_KEYS: The flux /flux/metric_data and /flux/metric_data_post
+    endpoints are controllered via API keys.  Each API key can additionally
+    specific a metric namespace prefix to prefix all metric names submitted with
+    the key with the defined namespace prefix.
+    Each API key must be a 32 character alphanumeric string [a-Z][0-9]
+    The trailing dot of the namespace prefix must not be specified it will be
+    automatically added as the separator between the namespace prefix and the
+    metric name.
+:vartype FLUX_API_KEYS: dict
+
+- **Example**::
+
+    FLUX_API_KEYS = {
+        'ZlJXpBL6QVuZg5KL4Vwrccvl8Bl3bBjC': None,
+        'KYRsv508FJpVg7pr11vnZTbeu11UvUqR': 'warehouse-1'
+    }
+
+"""
+
 FLUX_BACKLOG = 254
 """
 :var FLUX_BACKLOG: The maximum number of pending connections.  This refers to


### PR DESCRIPTION
IssueID #3694: flux - POST multiple metrics

- Added the ability to POST multiple metrics in a single request
- FLUX_API_KEYS to settings
- Added the validation of key against FLUX_API_KEYS or FLUX_SELF_API_KEY for
  flux requests
- Handle Redis and literal_eval separately in worker

Modified:
docs/flux.rst
skyline/flux/listen.py
skyline/flux/worker.py
skyline/settings.py