### PR TITLE
FLUX_ZERO_FILL_NAMESPACES

### DIFF
--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -2811,6 +2811,27 @@ FLUX_UPLOADS_KEYS = {}
 
 """
 
+FLUX_ZERO_FILL_NAMESPACES = []
+"""
+:var FLUX_ZERO_FILL_NAMESPACES: For each namespace or namespace elements
+    declared in this list, flux will send 0 if no data is recieved for a
+    metric in the namespace in the last 60 seconds.  This enables Skyline to
+    fill sparsely populated metrics with 0 where appropriate, continous data
+    time series are better for analysing, especially in terms of features
+    profiles.  The namespaces declared here can be absolute metric names,
+    elements or a regex of the namespace.
+:vartype FLUX_ZERO_FILL_NAMESPACES: list
+
+- **Example**::
+
+    FLUX_ZERO_FILL_NAMESPACES = [
+        'nginx.errors',
+        'external_sites.www_example_com.avg_pageload',
+        'sites.avg_pageload',
+    ]
+
+"""
+
 
 FLUX_SEND_TO_STATSD = False
 """


### PR DESCRIPTION
IssueID #3708: FLUX_ZERO_FILL_NAMESPACES

- Added FLUX_ZERO_FILL_NAMESPACES to settings
- Create the flux.zero_fill_metrics Redis set in analyzer
- In flux worker send 0 if metric in the flux.zero_fill_metrics Redis set has
  not submitted data in the last 60 seconds.

Modified:
skyline/analyzer/analyzer.py
skyline/flux/worker.py
skyline/settings.py