### PR TITLE
Refresh mirage.metrics_expiration_times for batch processing

### DIFF
--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -675,7 +675,7 @@ def api():
         logger.info('/api?snab request with anomaly_id - %s' % (
             str(anomaly_id)))
         result = None
-        snab_results = ['tP', 'fP', 'tN', 'fN', 'unsure']
+        snab_results = ['tP', 'fP', 'tN', 'fN', 'unsure', 'NULL']
         if 'result' in request.args:
             snab_result = request.args.get('result', None)
             if snab_result not in snab_results:

--- a/updates/sql/v2.1.0.sql
+++ b/updates/sql/v2.1.0.sql
@@ -44,3 +44,5 @@ CREATE TABLE IF NOT EXISTS `algorithm_groups` (
   INDEX `algorithm_group_id` (`id`,`algorithm_group`)) ENGINE=InnoDB;
 INSERT INTO `algorithm_groups` (algorithm_group) VALUES ('three-sigma');
 INSERT INTO `algorithm_groups` (algorithm_group) VALUES ('matrixprofile');
+
+INSERT INTO `sql_versions` (version) VALUES ('2.1.0');


### PR DESCRIPTION
IssueID #3766: Refresh mirage.metrics_expiration_times for batch processing
IssueID #3662: Change mirage.last_check keys to timestamp value
IssueID #3486: analyzer_batch
IssueID #3480: batch_processing

- Refresh the mirage.metrics_expiration_times Redis set in Analyzer, this is an
  idempotent change as the set is also managed in Mirage but only on metric name
  so if the expiry changes it is handled in Analyzer.

Modified:
skyline/analyzer/analyzer.py