### PR TITLE
skyline_functions - sanitise_graphite_url

### DIFF
--- a/skyline/analyzer/analyzer.py
+++ b/skyline/analyzer/analyzer.py
@@ -3981,7 +3981,10 @@ class Analyzer(Thread):
                             if waterfall_alert[0] in MIRAGE_ALWAYS_METRICS:
                                 # If triggered_algorithms is less than CONSENSUS
                                 # do not alert
-                                if len(waterfall_alert[4][5]) > settings.CONSENSUS:
+                                # @modified 20201009 - Bug #3776: waterfall_alert - no analyzer triggered_algorithms in waterfall_panorama_data on MIRAGE_ALWAYS_METRICS
+                                # Correct the operator
+                                # if len(waterfall_alert[4][5]) > settings.CONSENSUS:
+                                if len(waterfall_alert[4][5]) < settings.CONSENSUS:
                                     append_waterfall_alert = False
                                     logger.info('not waterfall alerting for MIRAGE_ALWAYS_METRICS metric that has no  item to alert on from Redis set %s - %s' % (
                                         redis_set, str(waterfall_alert)))

--- a/skyline/crucible/crucible.py
+++ b/skyline/crucible/crucible.py
@@ -64,7 +64,10 @@ import settings
 from skyline_functions import (
     fail_check, mkdir_p, write_data_to_file, filesafe_metricname,
     # @added 20200506 - Feature #3532: Sort all time series
-    sort_timeseries)
+    sort_timeseries,
+    # @added 20201009 - Feature #3780: skyline_functions - sanitise_graphite_url
+    #                   Bug #3778: Handle single encoded forward slash requests to Graphite
+    sanitise_graphite_url)
 
 from crucible_algorithms import run_algorithms
 
@@ -905,6 +908,12 @@ class Crucible(Thread):
                         use_timeout = int(connect_timeout)
                     if settings.ENABLE_CRUCIBLE_DEBUG:
                         logger.info('use_timeout - %s' % (str(use_timeout)))
+
+                    # @added 20201009 - Feature #3780: skyline_functions - sanitise_graphite_url
+                    #                   Bug #3778: Handle single encoded forward slash requests to Graphite
+                    sanitised = False
+                    sanitised, url = sanitise_graphite_url(skyline_app, url)
+
                     try:
                         r = requests.get(url, timeout=use_timeout)
                         js = r.json()

--- a/skyline/flux/populate_metric_worker.py
+++ b/skyline/flux/populate_metric_worker.py
@@ -47,7 +47,10 @@ if True:
         get_redis_conn,
         # @added 20191128 - Bug #3266: py3 Redis binary objects not strings
         #                   Branch #3262: py3
-        get_redis_conn_decoded)
+        get_redis_conn_decoded,
+        # @added 20201009 - Feature #3780: skyline_functions - sanitise_graphite_url
+        #                   Bug #3778: Handle single encoded forward slash requests to Graphite
+        sanitise_graphite_url)
 
 # @modified 20191129 - Branch #3262: py3
 # Consolidate flux logging
@@ -310,6 +313,12 @@ class PopulateMetricWorker(Process):
                                 settings.GRAPHITE_RENDER_URI, graphite_from, metric)
                         logger.info('populate_metric_worker :: using Graphite URL - %s' % (
                             url))
+
+                        # @added 20201009 - Feature #3780: skyline_functions - sanitise_graphite_url
+                        #                   Bug #3778: Handle single encoded forward slash requests to Graphite
+                        sanitised = False
+                        sanitised, url = sanitise_graphite_url(skyline_app, url)
+
                         r = requests.get(url)
                         if r.status_code == 200:
                             js = []
@@ -423,6 +432,11 @@ class PopulateMetricWorker(Process):
                     except:
                         logger.info(traceback.format_exc())
                         logger.error('error :: populate_metric_worker :: failed to rewrite URL')
+
+                # @added 20201009 - Feature #3780: skyline_functions - sanitise_graphite_url
+                #                   Bug #3778: Handle single encoded forward slash requests to Graphite
+                sanitised = False
+                sanitised, fetch_url = sanitise_graphite_url(skyline_app, fetch_url)
 
                 success = False
                 try:


### PR DESCRIPTION
IssueID #3780: skyline_functions - sanitise_graphite_url
IssueID #3776: waterfall_alert - no analyzer triggered_algorithms in waterfall_panorama_data on MIRAGE_ALWAYS_METRICS

- Added sanitise_graphite_url function to skyline_functions to handle double
  encoding of forward slashes in metric names from %2F to %252F on requests made
  to Graphite
- Corrected datapoint, timestamp order in MIRAGE_ALWAYS_METRICS waterfall_data

Modified:
skyline/analyzer/analyzer.py
skyline/crucible/crucible.py
skyline/flux/populate_metric_worker.py
skyline/mirage/mirage.py
skyline/skyline_functions.py
skyline/vista/fetcher.py