### PR TITLE
skyline_functions - sanitise_graphite_url

### DIFF
--- a/skyline/skyline_functions.py
+++ b/skyline/skyline_functions.py
@@ -2383,7 +2383,7 @@ def sanitise_graphite_url(current_skyline_app, graphite_url):
 
     if '+' in url:
         try:
-            url = graphite_url.replace('+', '%2B')
+            url = url.replace('+', '%2B')
             sanitised = True
             try:
                 current_skyline_app_logger = str(current_skyline_app) + 'Log'


### PR DESCRIPTION
IssueID #3780: skyline_functions - sanitise_graphite_url

- encode + to %2B in metric names on requests made to Graphite

Modified:
skyline/skyline_functions.py