### PR TITLE
flux changes

### DIFF
--- a/skyline/flux/flux.py
+++ b/skyline/flux/flux.py
@@ -2,6 +2,10 @@ import sys
 import os
 from multiprocessing import Queue
 
+# @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+from ast import literal_eval
+import traceback
+
 import falcon
 
 sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
@@ -11,6 +15,8 @@ sys.path.insert(0, os.path.dirname(__file__))
 # This prevents flake8 E402 - module level import not at top of file
 if True:
     import settings
+    # @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+    from skyline_functions import get_redis_conn_decoded
     from logger import set_up_logging
     from listen import MetricData, MetricDataPost
     # from listen_post import MetricDataPost
@@ -25,17 +31,73 @@ if True:
     if flux_process_uploads:
         from uploaded_data_worker import UploadedDataWorker
 
+# @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+try:
+    FLUX_PERSIST_QUEUE = settings.FLUX_PERSIST_QUEUE
+except:
+    FLUX_PERSIST_QUEUE = False
+
 logger = set_up_logging(None)
 pid = os.getpid()
 logger.info('flux :: starting flux listening on %s with pid %s' % (str(settings.FLUX_IP), str(pid)))
 
-logger.info('flux :: starting worker')
+logger.info('flux :: creating queue httpMetricDataQueue')
 # @modified 20191010 - Bug #3254: flux.populateMetricQueue Full
 # httpMetricDataQueue = Queue(maxsize=3000)
 # @modified 20191129 - Bug #3254: flux.populateMetricQueue Full
 # Set to infinite
 # httpMetricDataQueue = Queue(maxsize=30000)
 httpMetricDataQueue = Queue(maxsize=0)
+
+# @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+redis_conn_decoded = get_redis_conn_decoded('flux')
+logger.info('flux :: checked flux.queue Redis set to add any persisted items to the queue')
+saved_queue_data = []
+saved_queue_data_raw = None
+try:
+    saved_queue_data_raw = redis_conn_decoded.smembers('flux.queue')
+except:
+    saved_queue_data_raw = None
+if not FLUX_PERSIST_QUEUE and saved_queue_data_raw:
+    logger.info('flux :: flux.queue Redis set found but FLUX_PERSIST_QUEUE is set to %s' % str(FLUX_PERSIST_QUEUE))
+    logger.info('flux :: deleting flux.queue Redis set')
+    try:
+        redis_conn_decoded.delete('flux.queue')
+    except:
+        saved_queue_data_raw = None
+    saved_queue_data_raw = None
+if saved_queue_data_raw:
+    logger.info('flux :: %s raw items found in the flux.queue Redis set' % str(len(saved_queue_data_raw)))
+    for item in saved_queue_data_raw:
+        queue_item = literal_eval(item)
+        saved_queue_data.append(queue_item)
+saved_queue_data_put_error_logged = False
+saved_items_added_to_queue = 0
+if saved_queue_data:
+    logger.info('flux :: %s items in the flux.queue Redis set to add to queue' % str(len(saved_queue_data)))
+    for metric_data in saved_queue_data:
+        try:
+            httpMetricDataQueue.put(metric_data, block=False)
+            saved_items_added_to_queue += 1
+        except:
+            if not saved_queue_data_put_error_logged:
+                logger.error(traceback.format_exc())
+                logger.error('error :: failed to add saved_queue_data item to flux.httpMetricDataQueue - %s' % str(metric_data))
+                saved_queue_data_put_error_logged = True
+    logger.info('flux :: %s items from the flux.queue Redis set added to queue' % str(saved_items_added_to_queue))
+    try:
+        metric_data_queue_size = httpMetricDataQueue.qsize()
+        logger.info('flux :: httpMetricDataQueue queue size is now - %s' % str(metric_data_queue_size))
+    except:
+        logger.error(traceback.format_exc())
+        logger.error('error :: failed to determine size of queue httpMetricDataQueue')
+else:
+    if FLUX_PERSIST_QUEUE:
+        logger.info('flux :: there were no items in the flux.queue Redis set to add to the queue')
+    else:
+        logger.info('flux :: FLUX_PERSIST_QUEUE is set to %s, not persisting' % str(FLUX_PERSIST_QUEUE))
+
+logger.info('flux :: starting %s worker/s' % str(settings.FLUX_WORKERS))
 Worker(httpMetricDataQueue, pid).start()
 
 # @modified 20191010 - Bug #3254: flux.populateMetricQueue Full

--- a/skyline/flux/worker.py
+++ b/skyline/flux/worker.py
@@ -1,6 +1,7 @@
 import sys
 import os.path
 from os import kill
+from os import getpid
 import traceback
 # @modified 20191115 - Branch #3262: py3
 # from multiprocessing import Queue, Process
@@ -12,6 +13,13 @@ except ImportError:
     from queue import Empty  # Python 3
 from time import sleep, time
 from ast import literal_eval
+
+# @added 20201019 - Feature #3790: flux - pickle to Graphite
+# bandit [B403:blacklist] Consider possible security implications associated
+# with pickle module.  These have been considered.
+import pickle  # nosec
+import socket
+import struct
 
 # from redis import StrictRedis
 import graphyte
@@ -48,6 +56,30 @@ try:
     FLUX_ZERO_FILL_NAMESPACES = settings.FLUX_ZERO_FILL_NAMESPACES
 except:
     FLUX_ZERO_FILL_NAMESPACES = []
+
+# added 20201016 - Feature #3788: snab_flux_load_test
+# Wrap per metric logging in if FLUX_VERBOSE_LOGGING
+try:
+    FLUX_VERBOSE_LOGGING = settings.FLUX_VERBOSE_LOGGING
+except:
+    FLUX_VERBOSE_LOGGING = True
+
+# @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+try:
+    FLUX_PERSIST_QUEUE = settings.FLUX_PERSIST_QUEUE
+except:
+    FLUX_PERSIST_QUEUE = False
+
+# @added 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+try:
+    FLUX_CHECK_LAST_TIMESTAMP = settings.FLUX_CHECK_LAST_TIMESTAMP
+except:
+    FLUX_CHECK_LAST_TIMESTAMP = True
+try:
+    VISTA_ENABLED = settings.VISTA_ENABLED
+except:
+    VISTA_ENABLED = False
+
 
 parent_skyline_app = 'flux'
 
@@ -106,6 +138,7 @@ class Worker(Process):
         self.q = queue
         self.parent_pid = parent_pid
         self.daemon = True
+        self.current_pid = getpid()
 
     def check_if_parent_is_alive(self):
         """
@@ -121,6 +154,72 @@ class Worker(Process):
         Called when the process intializes.
         """
 
+        def pickle_data_to_graphite(data):
+
+            message = None
+            try:
+                payload = pickle.dumps(data, protocol=2)
+                header = struct.pack("!L", len(payload))
+                message = header + payload
+            except:
+                logger.error(traceback.format_exc())
+                logger.error('error :: worker :: failed to pickle to send to Graphite')
+                return False
+            if message:
+                try:
+                    sock = socket.socket()
+                    sock.connect((CARBON_HOST, settings.FLUX_CARBON_PICKLE_PORT))
+                    sock.sendall(message)
+                    sock.close()
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: worker :: failed to send pickle data to Graphite')
+                    return False
+            else:
+                logger.error(traceback.format_exc())
+                logger.error('error :: worker :: failed to pickle metric data into message')
+                return False
+            return True
+
+        def submit_pickle_data_to_graphite(pickle_data):
+            number_of_datapoints = len(pickle_data)
+            data_points_sent = 0
+            smallListOfMetricTuples = []
+            tuples_added = 0
+            for data in pickle_data:
+                smallListOfMetricTuples.append(data)
+                tuples_added += 1
+                if tuples_added >= 480:
+                    pickle_data_sent = pickle_data_to_graphite(smallListOfMetricTuples)
+                    # Reduce the speed of submissions to Graphite
+                    # if there are lots of data points
+                    if number_of_datapoints > 4000:
+                        sleep(0.3)
+                    if pickle_data_sent:
+                        data_points_sent += tuples_added
+                        logger.info('worker :: sent %s/%s of %s data points to Graphite via pickle' % (
+                            str(tuples_added), str(data_points_sent),
+                            str(number_of_datapoints)))
+                        smallListOfMetricTuples = []
+                        tuples_added = 0
+                    else:
+                        logger.error('error :: worker :: failed to send %s data points to Graphite via pickle' % (
+                            str(tuples_added)))
+                        return False
+            if smallListOfMetricTuples:
+                tuples_to_send = len(smallListOfMetricTuples)
+                pickle_data_sent = pickle_data_to_graphite(smallListOfMetricTuples)
+                if pickle_data_sent:
+                    data_points_sent += tuples_to_send
+                    logger.info('worker :: sent the last %s/%s of %s data points to Graphite via pickle' % (
+                        str(tuples_to_send), str(data_points_sent),
+                        str(number_of_datapoints)))
+                else:
+                    logger.error('error :: failed to send the last %s data points to Graphite via pickle' % (
+                        str(tuples_to_send)))
+                    return False
+            return True
+
         logger.info('worker :: starting worker')
 
         last_sent_to_graphite = int(time())
@@ -129,6 +228,26 @@ class Worker(Process):
         # @added 20200827 - Feature #3708: FLUX_ZERO_FILL_NAMESPACES
         last_zero_fill_to_graphite = 0
         metrics_sent = []
+
+        remove_from_flux_queue_redis_set = []
+
+        # @added 20201019 - Feature #3790: flux - pickle to Graphite
+        pickle_data = []
+        # send_to_reciever = 'line'
+        send_to_reciever = 'pickle'
+        metric_data_queue_size = self.q.qsize()
+        if metric_data_queue_size > 10:
+            send_to_reciever = 'pickle'
+
+        # @added 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+        # Even if flux.last Redis keys are disabled in flux they are used in
+        # Vista
+        vista_metrics = []
+        if not FLUX_CHECK_LAST_TIMESTAMP and VISTA_ENABLED:
+            try:
+                vista_metrics = list(self.redis_conn_decoded.sscan_iter('vista.metrics', match='*'))
+            except:
+                vista_metrics = []
 
         # Populate API keys and tokens in memcache
         # python-2.x and python3.x handle while 1 and while True differently
@@ -169,8 +288,81 @@ class Worker(Process):
                 metric_data = self.q.get(True, 1)
 
             except Empty:
+                if pickle_data:
+                    pickle_data_submitted = submit_pickle_data_to_graphite(pickle_data)
+                    if pickle_data_submitted:
+                        pickle_data = []
                 logger.info('worker :: queue is empty and timed out')
                 sleep(1)
+                # @added 20201017 - Feature #3788: snab_flux_load_test
+                # Send to Graphite even if worker gets no metrics
+                if (int(time()) - last_sent_to_graphite) >= 60:
+                    logger.info('worker :: metrics_sent_to_graphite in last 60 seconds - %s' % str(metrics_sent_to_graphite))
+                    skyline_metric = '%s.metrics_sent_to_graphite' % skyline_app_graphite_namespace
+                    try:
+                        # @modified 20191008 - Feature #3250: Allow Skyline to send metrics to another Carbon host
+                        # graphyte.send(skyline_metric, metrics_sent_to_graphite, time_now)
+                        send_graphite_metric(skyline_app, skyline_metric, metrics_sent_to_graphite)
+                        last_sent_to_graphite = int(time())
+                        metrics_sent_to_graphite = 0
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: worker :: failed to send_graphite_metric %s with %s' % (
+                            skyline_metric, str(metrics_sent_to_graphite)))
+                    metric_data_queue_size = 0
+                    try:
+                        metric_data_queue_size = self.q.qsize()
+                        logger.info('worker :: flux.httpMetricDataQueue queue size - %s' % str(metric_data_queue_size))
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: worker :: failed to determine size of queue flux.httpMetricDataQueue')
+                    skyline_metric = '%s.httpMetricDataQueue.size' % skyline_app_graphite_namespace
+                    try:
+                        send_graphite_metric(skyline_app, skyline_metric, metric_data_queue_size)
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: worker :: failed to send_graphite_metric %s with %s' % (
+                            skyline_metric, str(metrics_sent_to_graphite)))
+                    # @added 20201019 - Feature #3790: flux - pickle to Graphite
+                    if metric_data_queue_size > 10:
+                        send_to_reciever = 'pickle'
+                    else:
+                        send_to_reciever = 'line'
+                    send_to_reciever = 'pickle'
+                    # @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+                    if FLUX_PERSIST_QUEUE:
+                        redis_set_size = 0
+                        try:
+                            redis_set_size = self.redis_conn.scard('flux.queue')
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: worker :: failed to determine size of flux.queue Redis set')
+                        logger.info('worker - flux.queue Redis set size of %s before removal of %s items' % (
+                            str(redis_set_size), str(len(remove_from_flux_queue_redis_set))))
+                        if remove_from_flux_queue_redis_set:
+                            try:
+                                self.redis_conn.srem('flux.queue', *set(remove_from_flux_queue_redis_set))
+                                remove_from_flux_queue_redis_set = []
+                            except:
+                                logger.error(traceback.format_exc())
+                                logger.error('error :: worker :: failed to remove multiple items from flux.queue Redis set')
+                            try:
+                                redis_set_size = self.redis_conn.scard('flux.queue')
+                            except:
+                                logger.error(traceback.format_exc())
+                                logger.error('error :: worker :: failed to determine size of flux.queue Redis set')
+                            logger.info('worker - flux.queue Redis set size of %s after the removal of items' % (
+                                str(redis_set_size)))
+                            remove_from_flux_queue_redis_set = []
+                    # @added 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+                    # Even if flux.last Redis keys are disabled in flux they are used in
+                    # Vista
+                    vista_metrics = []
+                    if not FLUX_CHECK_LAST_TIMESTAMP and VISTA_ENABLED:
+                        try:
+                            vista_metrics = list(self.redis_conn_decoded.sscan_iter('vista.metrics', match='*'))
+                        except:
+                            vista_metrics = []
             except NotImplementedError:
                 pass
             except KeyboardInterrupt:
@@ -183,6 +375,19 @@ class Worker(Process):
             # @added 20200206 - Feature #3444: Allow flux to backfill
             # Added backfill
             backfill = False
+
+            # @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+            if metric_data and FLUX_PERSIST_QUEUE:
+                try:
+                    # Do not remove each individual metrics from the flux.queue
+                    # Redis set, add to a list that is removed in one srem *set
+                    # operation each 60 seconds.  This is a more perfomant
+                    # method and requires a single blocking call for a batch of
+                    # metrics, rather than a blocking call for every metric.
+                    # self.redis_conn.srem('flux.queue', str(metric_data))
+                    remove_from_flux_queue_redis_set.append(str(metric_data))
+                except:
+                    pass
 
             if metric_data:
                 try:
@@ -199,6 +404,19 @@ class Worker(Process):
                     logger.error('error :: worker :: failed to interpolate metric, value, timestamp from metric_data - %s' % str(metric_data))
                     continue
 
+                # @added 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+                # Only check flux.last key if this is not backfill and
+                # FLUX_CHECK_LAST_TIMESTAMP is enable or it is in VISTA_ENABLED
+                cache_key = None
+                if FLUX_CHECK_LAST_TIMESTAMP:
+                    cache_key = 'flux.last.%s' % metric
+                check_flux_last_key = False
+                if not backfill and FLUX_CHECK_LAST_TIMESTAMP:
+                    check_flux_last_key = True
+                if VISTA_ENABLED:
+                    if metric in vista_metrics:
+                        check_flux_last_key = True
+
                 if settings.FLUX_SEND_TO_CARBON:
                     # Best effort de-duplicate the data
                     valid_data = True
@@ -209,8 +427,13 @@ class Worker(Process):
 
                     # @modified 20200206 - Feature #3444: Allow flux to backfill
                     # Only check flux.last key if this is not backfill
-                    if not backfill:
-                        cache_key = 'flux.last.%s' % metric
+                    # @modified 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+                    # Use the check_flux_last_key value determined above
+                    # if not backfill:
+                    if check_flux_last_key:
+                        # @modified 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+                        # Set cache_key outside the conditional block
+                        # cache_key = 'flux.last.%s' % metric
                         last_metric_timestamp = None
                         try:
                             # @modified 20191128 - Bug #3266: py3 Redis binary objects not strings
@@ -245,22 +468,35 @@ class Worker(Process):
 
                     if valid_data:
                         submittedToGraphite = False
-                        try:
-                            graphyte.send(metric, value, timestamp)
+                        if send_to_reciever == 'line':
+                            try:
+                                graphyte.send(metric, value, timestamp)
+                                submittedToGraphite = True
+                                # modified 20201016 - Feature #3788: snab_flux_load_test
+                                if FLUX_VERBOSE_LOGGING:
+                                    logger.info('worker :: sent %s, %s, %s to Graphite' % (str(metric), str(value), str(timestamp)))
+                                metrics_sent_to_graphite += 1
+                                # @added 20200827 - Feature #3708: FLUX_ZERO_FILL_NAMESPACES
+                                metrics_sent.append(metric)
+                            except:
+                                logger.error(traceback.format_exc())
+                                logger.error('error :: worker :: failed to send metric data to Graphite for %s' % str(metric))
+                                metric = None
+                        if send_to_reciever == 'pickle':
+                            tuple_data = (metric, (int(timestamp), float(value)))
+                            pickle_data.append(tuple_data)
                             submittedToGraphite = True
-                            logger.info('worker :: sent %s, %s, %s to Graphite' % (str(metric), str(value), str(timestamp)))
                             metrics_sent_to_graphite += 1
-                            # @added 20200827 - Feature #3708: FLUX_ZERO_FILL_NAMESPACES
                             metrics_sent.append(metric)
-                        except:
-                            logger.error(traceback.format_exc())
-                            logger.error('error :: worker :: failed to send metric data to Graphite for %s' % str(metric))
-                            metric = None
+
                         if submittedToGraphite:
                             # Update the metric Redis flux key
                             # @modified 20200206 - Feature #3444: Allow flux to backfill
                             # Only update the flux.last key if this is not backfill
-                            if not backfill:
+                            # @modified 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+                            # Use the check_flux_last_key value determined above
+                            # if not backfill:
+                            if check_flux_last_key:
                                 metric_data = [timestamp, value]
                                 self.redis_conn.set(cache_key, str(metric_data))
                             # @added 20200213 - Bug #3448: Repeated airgapped_metrics
@@ -281,17 +517,38 @@ class Worker(Process):
                                 except Exception as e:
                                     logger.error('error :: failed to could not set Redis flux.filled key: %s' % e)
                     else:
-                        logger.info('worker :: discarded %s, %s, %s as a data point for %s has already been submitted to Graphite' % (
-                            str(metric), str(value), str(timestamp), str(timestamp)))
+                        # modified 20201016 - Feature #3788: snab_flux_load_test
+                        if FLUX_VERBOSE_LOGGING:
+                            logger.info('worker :: discarded %s, %s, %s as a data point for %s has already been submitted to Graphite' % (
+                                str(metric), str(value), str(timestamp), str(timestamp)))
                 else:
                     logger.info('worker :: settings.FLUX_SEND_TO_CARBON is set to %s, discarded %s, %s, %s' % (
                         str(settings.FLUX_SEND_TO_CARBON), str(metric), str(value), str(timestamp)))
 
                 if settings.FLUX_SEND_TO_STATSD:
                     statsd_conn.incr(metric, value, timestamp)
-                    logger.info('worker sent %s, %s, %s to statsd' % (metric, str(value), str(timestamp)))
+                    # modified 20201016 - Feature #3788: snab_flux_load_test
+                    if FLUX_VERBOSE_LOGGING:
+                        logger.info('worker sent %s, %s, %s to statsd' % (metric, str(value), str(timestamp)))
                     # @added 20200827 - Feature #3708: FLUX_ZERO_FILL_NAMESPACES
                     metrics_sent.append(metric)
+
+                submit_pickle_data = False
+                if pickle_data:
+                    number_of_datapoints = len(pickle_data)
+                    if number_of_datapoints >= 1000:
+                        submit_pickle_data = True
+                    else:
+                        try:
+                            metric_data_queue_size = self.q.qsize()
+                        except:
+                            metric_data_queue_size = 0
+                        if metric_data_queue_size == 0:
+                            submit_pickle_data = True
+                if submit_pickle_data:
+                    pickle_data_submitted = submit_pickle_data_to_graphite(pickle_data)
+                    if pickle_data_submitted:
+                        pickle_data = []
 
             time_now = int(time())
 
@@ -314,7 +571,9 @@ class Worker(Process):
                         if flux_zero_fill_metric not in metrics_sent:
                             try:
                                 graphyte.send(flux_zero_fill_metric, 0.0, time_now)
-                                logger.info('worker :: zero fill - sent %s, %s, %s to Graphite' % (str(flux_zero_fill_metric), str(0.0), str(time_now)))
+                                # modified 20201016 - Feature #3788: snab_flux_load_test
+                                if FLUX_VERBOSE_LOGGING:
+                                    logger.info('worker :: zero fill - sent %s, %s, %s to Graphite' % (str(flux_zero_fill_metric), str(0.0), str(time_now)))
                                 metrics_sent_to_graphite += 1
                                 metrics_sent.append(metric)
                             except:
@@ -325,6 +584,10 @@ class Worker(Process):
                     metrics_sent = []
 
             if (time_now - last_sent_to_graphite) >= 60:
+                if pickle_data:
+                    pickle_data_submitted = submit_pickle_data_to_graphite(pickle_data)
+                    if pickle_data_submitted:
+                        pickle_data = []
                 logger.info('worker :: metrics_sent_to_graphite in last 60 seconds - %s' % str(metrics_sent_to_graphite))
                 skyline_metric = '%s.metrics_sent_to_graphite' % skyline_app_graphite_namespace
                 try:
@@ -337,3 +600,56 @@ class Worker(Process):
                     logger.error(traceback.format_exc())
                     logger.error('error :: worker :: failed to send_graphite_metric %s with %s' % (
                         skyline_metric, str(metrics_sent_to_graphite)))
+                metric_data_queue_size = 0
+                try:
+                    metric_data_queue_size = self.q.qsize()
+                    logger.info('worker :: flux.httpMetricDataQueue queue size - %s' % str(metric_data_queue_size))
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: worker :: failed to determine size of queue flux.httpMetricDataQueue')
+                skyline_metric = '%s.httpMetricDataQueue.size' % skyline_app_graphite_namespace
+                try:
+                    send_graphite_metric(skyline_app, skyline_metric, metric_data_queue_size)
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: worker :: failed to send_graphite_metric %s with %s' % (
+                        skyline_metric, str(metrics_sent_to_graphite)))
+                # @added 20201019 - Feature #3790: flux - pickle to Graphite
+                if metric_data_queue_size > 10:
+                    send_to_reciever = 'pickle'
+                else:
+                    send_to_reciever = 'line'
+                # @added 20201018 - Feature #3798: FLUX_PERSIST_QUEUE
+                if FLUX_PERSIST_QUEUE:
+                    redis_set_size = 0
+                    try:
+                        redis_set_size = self.redis_conn.scard('flux.queue')
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: worker :: failed to determine size of flux.queue Redis set')
+                    logger.info('worker - flux.queue Redis set size %s before removal of %s items' % (
+                        str(redis_set_size), str(len(remove_from_flux_queue_redis_set))))
+                    if remove_from_flux_queue_redis_set:
+                        try:
+                            self.redis_conn.srem('flux.queue', *set(remove_from_flux_queue_redis_set))
+                            remove_from_flux_queue_redis_set = []
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: worker :: failed to remove multiple items from flux.queue Redis set')
+                        try:
+                            redis_set_size = self.redis_conn.scard('flux.queue')
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: worker :: failed to determine size of flux.queue Redis set')
+                        logger.info('worker - flux.queue Redis set size of %s after the removal of items' % (
+                            str(redis_set_size)))
+                        remove_from_flux_queue_redis_set = []
+                # @added 20201020 - Feature #3796: FLUX_CHECK_LAST_TIMESTAMP
+                # Even if flux.last Redis keys are disabled in flux they are used in
+                # Vista
+                vista_metrics = []
+                if not FLUX_CHECK_LAST_TIMESTAMP and VISTA_ENABLED:
+                    try:
+                        vista_metrics = list(self.redis_conn_decoded.sscan_iter('vista.metrics', match='*'))
+                    except:
+                        vista_metrics = []

--- a/skyline/skyline_functions.py
+++ b/skyline/skyline_functions.py
@@ -2066,6 +2066,15 @@ def is_batch_metric(current_skyline_app, base_name):
     except:
         BATCH_PROCESSING_NAMESPACES = []
 
+    # @added 20201017 - Feature #3818: ANALYZER_BATCH_PROCESSING_OVERFLOW_ENABLED
+    try:
+        ANALYZER_BATCH_PROCESSING_OVERFLOW_ENABLED = settings.ANALYZER_BATCH_PROCESSING_OVERFLOW_ENABLED
+    except:
+        ANALYZER_BATCH_PROCESSING_OVERFLOW_ENABLED = False
+    if ANALYZER_BATCH_PROCESSING_OVERFLOW_ENABLED:
+        if not BATCH_PROCESSING_NAMESPACES:
+            return False
+
     debug_is_batch_metric = None
 
     batch_metric = False
@@ -2424,9 +2433,9 @@ def encode_graphite_metric_name(current_skyline_app, metric):
     # encoded_graphite_metric_name = urllib.parse.quote(encoded_graphite_metric_name)
 
     # Double encode forward slash
-    if '.%2F' in encoded_graphite_metric_name:
+    if '%2F' in encoded_graphite_metric_name:
         try:
-            encoded_graphite_metric_name = encoded_graphite_metric_name.replace('.%2F', '.%252F')
+            encoded_graphite_metric_name = encoded_graphite_metric_name.replace('%2F', '%252F')
             try:
                 current_skyline_app_logger = str(current_skyline_app) + 'Log'
                 current_logger = logging.getLogger(current_skyline_app_logger)


### PR DESCRIPTION
IssueID #3798: FLUX_PERSIST_QUEUE
IssueID #3788: snab_flux_load_test
IssueID #3764: flux validate metric name
IssueID #3780: skyline_functions - sanitise_graphite_url
IssueID #3790: flux - pickle to Graphite
IssueID #3796: FLUX_CHECK_LAST_TIMESTAMP

- Allow flux to persist the queue in the flux.queue Redis set
- Added FLUX_VERBOSE_LOGGING to allow for disabling request and data logging
- flux validate metric name
- Use encode_graphite_metric_name function
- Change flux worker to pickle data to Graphite
- Allow the disabling of the use to the flux.last Redis keys with the added
  setting of FLUX_CHECK_LAST_TIMESTAMP
- Update docs

Modified:
docs/analyzer.rst
docs/flux.rst
skyline/flux/flux.py
skyline/flux/listen.py
skyline/flux/populate_metric_worker.py
skyline/flux/worker.py
skyline/skyline_functions.py