### PR TITLE
HORIZON_SHARDS

### DIFF
--- a/docs/horizon.rst
+++ b/docs/horizon.rst
@@ -30,3 +30,34 @@ will only have a finite amount of memory on your server, and so if you just let
 the Workers append all day long, you would run out of memory. The Roomba cycles
 through each metric in Redis and cuts it down so it is as long as
 `settings.FULL_DURATION`. It also dedupes and purges old metrics.
+
+HORIZON_SHARDS
+==============
+
+This is an advanced feature related to running multiple, distributed Skyline
+servers (and Graphite instances) in a replicated fashion.  This allows for all
+the Skyline servers to receiver all metrics but only analyze those metrics that
+are assigned to the specific server (shard).  This enables all Skyline servers
+that are running Horizon to receiver the entire metric population stream from
+multiple Graphite carbon-relays and drop (not submit to their Redis instance)
+any metrics that do not belong to their shard.
+
+.. code-block:: python
+
+  HORIZON_SHARDS = {
+      'skyline-server-1': 0,
+      'skyline-server-2': 1,
+      'skyline-server-3': 2,
+  }
+
+Shards are 0 indexed.
+
+If enabled the metric population is divided between the ``number_of_horizon_shards``
+declared in :mod:`settings.HORIZON_SHARDS` by calculating the ``zlib.alder32``
+hash value (an integer) and applying a modulo to it to determine if the metric
+belongs to the Horizon shard number assigned to that server.
+
+Although ``zlib.alder32`` is not a cryptographic hash it is **fast** and
+computes the same value across all Python version and platforms so it does the
+job.  Further the distribution of metrics is not an exact equal division of the
+metrics, but it is good enough.

--- a/docs/running-multiple-skylines.rst
+++ b/docs/running-multiple-skylines.rst
@@ -13,12 +13,33 @@ required, e.g. Luminosity.
 Some organisations have multiple Graphite instances for sharding, geographic or
 latency reasons.  In such a case it is possible that each Graphite instance
 would pickle to a Skyline instance and for there to be multiple Skyline
-instances.
+instances.  However...
+
+Running Skyline in a distributed, HA manner is mostly related to running the
+components of Skyline in this fashion, for example using Galera cluster to
+provide MariaDB replication.  Each of the components have their own high
+availability and clustering methods in most cases and the addition of haproxy,
+mysqlproxy, load balanced or round robin DNS can achieve a lot of redundancy.
+Defining how Skyline can be run in HA or clustered is beyond the scope of
+Skyline itself, it is more an exercise of operations and distributed systems
+which is beyond the scope of this documentation.
+
+However one word of caution, **do not cluster Redis**.  Although some sharded
+configuration may work, it is simpler just to use local Redis data.  Due to
+the metric time series constantly changing in Redis clustering or slaving
+results in most the entire Redis data store being shipped constantly, not
+desired.
+
+That said the actual Skyline modules have certain settings and configurations
+that are HA or distributed _aware_ to allow Skyline itself to provide the
+ability to use HA/clustered/distributed components.  This section deals with
+these.
 
 The following settings pertain to running multiple Skyline instances:
 
 - :mod:`settings.ALTERNATIVE_SKYLINE_URLS`
 - :mod:`settings.REMOTE_SKYLINE_INSTANCES`
+- :mod:`settings.HORIZON_SHARDS`
 
 With the introduction of Luminosity a requirement for Skyline to pull the time
 series data from remote Skyline instances was added to allow for cross
@@ -51,7 +72,7 @@ center.  Where the primary Graphite is pickling to a primary Skyline instance
 and a standby Graphite instance.  With the standby Graphite instance pickling
 data to the standby Skyline instance.
 
-.. code-block
+.. code-block::
 
                         graphite-1
                             |

--- a/skyline/horizon/agent.py
+++ b/skyline/horizon/agent.py
@@ -107,12 +107,28 @@ def run():
     Start the Horizon agent and logger.
     """
     if not isdir(settings.PID_PATH):
-        print ('pid directory does not exist at %s' % settings.PID_PATH)
+        print('pid directory does not exist at %s' % settings.PID_PATH)
         sys.exit(1)
 
     if not isdir(settings.LOG_PATH):
-        print ('log directory does not exist at %s' % settings.LOG_PATH)
+        print('log directory does not exist at %s' % settings.LOG_PATH)
         sys.exit(1)
+
+    # @added 20201103 - Feature #3820: HORIZON_SHARDS
+    try:
+        HORIZON_SHARDS = settings.HORIZON_SHARDS.copy()
+    except:
+        HORIZON_SHARDS = {}
+    horizon_shards_validated = True
+    if HORIZON_SHARDS:
+        for shard_host in HORIZON_SHARDS:
+            try:
+                int(HORIZON_SHARDS[shard_host])
+            except:
+                horizon_shards_validated = False
+        if not horizon_shards_validated:
+            print('the HORIZON_SHARDS dict in settings.py does not have valid shard numbers' % str(settings.HORIZON_SHARDS))
+            sys.exit(1)
 
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter("%(asctime)s :: %(process)s :: %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
@@ -132,7 +148,7 @@ def run():
     valid_settings = validate_settings_variables(skyline_app)
 
     if not valid_settings:
-        print ('error :: invalid variables in settings.py - cannot start')
+        print('error :: invalid variables in settings.py - cannot start')
         sys.exit(1)
 
     horizon = Horizon()

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -1340,6 +1340,39 @@ MAX_RESOLUTION = 1000
 :vartype MAX_RESOLUTION: int
 """
 
+HORIZON_SHARDS = {}
+"""
+:var HORIZON_SHARDS: ADVANCED FEATURE - A dictionary of Skyline hostnames and
+    there assigned shard value.
+:vartype HORIZON_SHARDS: dict
+
+This setting is only applicable to running Skyline Horizon services on multiple
+servers (and Graphite instances) in a replicated fashion.  This allows for all
+the Skyline servers to receiver all metrics but only analyze those metrics that
+are assigned to the specific server (shard).  This enables all Skyline servers
+that are running Horizon to receiver the entire metric population stream from
+mulitple Graphite carbon-relays and drop (not submit to their Redis instance)
+any metrics that do not belong to their shard.
+
+- **Example**::
+
+    HORIZON_SHARDS = {
+        'skyline-server-1': 0,
+        'skyline-server-2': 1,
+        'skyline-server-3': 2,
+    }
+
+Shard are 0 indexed.
+
+"""
+
+HORIZON_SHARD_DEBUG = False
+"""
+:var HORIZON_SHARD_DEBUG: For development only to log some sharding debug info
+    not for general use.
+:vartype HORIZON_SHARD_DEBUG: boolean
+"""
+
 SKIP_LIST = [
     # Skip the skyline namespaces, except horizon.  This prevents Skyline
     # populating a lot of anomalies related to timings, algorithm_breakdowns,


### PR DESCRIPTION
IssueID #3820: HORIZON_SHARDS

- Allow horizon to only submit metrics to Redis if they are assigned to the
  horizon shard.

Modified:
docs/horizon.rst
docs/running-multiple-skylines.rst
skyline/horizon/agent.py
skyline/horizon/worker.py
skyline/settings.py