### PR TITLE
webapp - analyzer_last_status API endoint

### DIFF
--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -158,6 +158,45 @@ Or if no metrics of no metrics are set to alert <code>{"data":{"metrics":[]},"st
 		    </tbody>
 		  </table>
 
+	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/api?analyzer_last_status</span></span></h4>
+  		  <table class="table table-hover">
+  		    <thead>
+  		      <tr>
+  		        <th>Name</th>
+  		        <th>Description</th>
+  		      </tr>
+  		    </thead>
+  		    <tbody>
+  		      <tr>
+  		        <td>Description:</td>
+  		        <td>Returns the last timestamp that Analyzer ran as a json object.  The Redis analyzer key is set every run with a TTL of 120 seconds</br>
+                  If the Redis key does not exist the request is responded to with HTTP status code <code>410 GONE</code>
+              </td>
+  		      </tr>
+  		      <tr>
+  		        <td>Endpoint:</td>
+  		        <td><a target='_blank' href="/api?analyzer_last_status">/api?analyzer_last_status</a></td>
+  		      </tr>
+  		      <tr>
+  		        <td>Method:</td>
+  		        <td>GET</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Request example:</td>
+		          <td><code>/api?analyzer_last_status</code></td>
+  		      </tr>
+  		      <tr>
+  		        <td>Responses:</td>
+  		        <td>200 - json response, example
+                  <code>
+{"data":{"timestamp":1604421547},"status":{}}
+</code><br>
+Or if Analyzer has not run in 120 seconds <code>{"data":{"timestamp":null},"status":{}}</code> with status code 410<br>
+              </td>
+  		      </tr>
+		    </tbody>
+		  </table>
+
 	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/api?anomaly</span></span></h4>
   		  <table class="table table-hover">
   		    <thead>

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -643,6 +643,23 @@ def version():
 # def data():
 def api():
 
+    # @added 20201103 - Feature #3770: webapp - analyzer_last_status API endoint
+    if 'analyzer_last_status' in request.args:
+        logger.info('/api?analyzer_last_status request')
+        analyzer_last_status = None
+        try:
+            analyzer_last_status = int(float(str(REDIS_CONN.get('analyzer'))))
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: Webapp could not get the analyzer key from Redis')
+        logger.info('/api?analyzer_last_status responding with %s' % str(analyzer_last_status))
+        data_dict = {"status": {}, "data": {"timestamp": analyzer_last_status}}
+        if not analyzer_last_status:
+            # Return with status code 410 Gone
+            logger.info('/api?analyzer_last_status responding with status code 410 GONE')
+            return jsonify(data_dict), 410
+        return jsonify(data_dict), 200
+
     # @added 20201007 - Feature #3770: webapp - batch_processing metrics API endoint
     if 'batch_processing_metrics' in request.args:
         logger.info('/api?batch_processing_metrics request')


### PR DESCRIPTION
IssueID #3770: webapp - analyzer_last_status API endoint

- Added api method to return the Redis analyzer key data

Modified:
skyline/webapp/templates/api.html
skyline/webapp/webapp.py