### PR TITLE
misc analyzer and metrics_manager changes

### DIFF
--- a/skyline/analyzer/metrics_manager.py
+++ b/skyline/analyzer/metrics_manager.py
@@ -1092,8 +1092,8 @@ class Metrics_Manager(Thread):
                         logger.error('error :: metrics_manager :: failed to stop spawn process')
 
             process_runtime = time() - now
-            if process_runtime < 60:
-                sleep_for = (60 - process_runtime)
+            if process_runtime < 300:
+                sleep_for = (300 - process_runtime)
                 logger.info('metrics_manager :: sleeping for %.2f seconds due to low run time...' % sleep_for)
                 sleep(sleep_for)
                 try:


### PR DESCRIPTION
IssueID #3830: metrics_manager
IssueID #3808: ANALYZER_DYNAMICALLY_ANALYZE_LOW_PRIORITY_METRICS
IssueID #3480: batch_processing
IssueID #2050: analyse_derivatives - change in monotonicity
IssueID #3734: waterfall alerts

- Use the metrics_manager mirage.hash_key.metrics_resolutions for Mirage metric
  resolutions rather that the individual mirage.metrics. Redis keys (3830)
- Disabled a number of functions in analyzer that are now run in metrics_manager
  via the if not ANALYZER_USE_METRICS_MANAGER conditional (3830)
- Changed metrics_manager from running every 60 seconds to 300 seconds (3830)
- Manage derivative metrics more efficiently and fix bug introduced for batch
  processing that results in the z.derivative_metric keys not being refreshed as
  it was setevery run if it existed.  Now only set once. (3480, 2050)
- Only assign as derivative metric if it evaluates as strictly_increasing_monotonicity
  more than once.  This prevents metrics which are for example at 0 all day then
  record a 1 from being classified as monotonic if the classification happens to
  occur when the metric is at 1, on the next classification runs if the metric
  is still at 1 or increasing then it will be classified as monotonic.  However
  if the metric returns to 0, this requirement to be classified multiple times
  ensures it is not incorrectly classified as monotonic.  Using the
  zz.derivative_metric Redis keys.  (3480, 2050)
- Now that alerts can get back to Analyzer via waterfall alerting from
  Ionosphere the new redis_conn_decoded function is required (3734)

Modified:
skyline/analyzer/analyzer.py
skyline/analyzer/metrics_manager.py