### PR TITLE
Add the real anomalyScore to the http alert

### DIFF
--- a/skyline/mirage/mirage.py
+++ b/skyline/mirage/mirage.py
@@ -3356,6 +3356,18 @@ class Mirage(Thread):
                                             # Do not modify the alert list object, create a new one
                                             new_alert = list(alert)
                                             new_alert.append(['anomaly_id', anomaly_id])
+                                            # @added 20201111 - Feature #3772: Add the anomaly_id to the http_alerter json
+                                            # Add the real anomalyScore
+                                            try:
+                                                if triggered_algorithms and algorithms_run:
+                                                    anomalyScore = len(triggered_algorithms) / len(algorithms_run)
+                                                else:
+                                                    anomalyScore = 1.0
+                                            except:
+                                                logger.error(traceback.format_exc())
+                                                logger.error('error :: failed to determine anomalyScore for %s' % base_name)
+                                                anomalyScore = 1.0
+                                            new_alert.append(['anomalyScore', anomalyScore])
 
                                         # @added 20200929 - Task #3748: POC SNAB
                                         #                   Branch #3068: SNAB

--- a/skyline/mirage/mirage_alerters.py
+++ b/skyline/mirage/mirage_alerters.py
@@ -2017,6 +2017,26 @@ def alert_http(alert, metric, second_order_resolution_seconds, context):
                 if not anomaly_id:
                     logger.error('error :: alert_http :: failed to determine anomaly_id from alert[4] or alert[5]')
 
+            # @added 20201111 - Feature #3772: Add the anomaly_id to the http_alerter json
+            # Add the real anomalyScore
+            anomalyScore = None
+            try:
+                anomalyScore_details = alert[5]
+                if anomalyScore_details[0] == 'anomalyScore':
+                    anomalyScore = anomalyScore_details[1]
+            except:
+                pass
+            if not anomalyScore:
+                try:
+                    anomalyScore_details = alert[6]
+                    if anomalyScore_details[0] == 'anomalyScore':
+                        anomalyScore = anomalyScore_details[1]
+                except:
+                    pass
+            if not anomalyScore:
+                logger.error('error :: alert_http :: failed to determine anomalyScore from alert[5] or alert[6] - set anomalyScore to 1.0')
+                anomalyScore = 1.0
+
             # @modified 20201007 - Feature #3772: Add the anomaly_id to the http_alerter json
             metric_alert_dict = {
                 "metric": str(metric[1]),


### PR DESCRIPTION
IssueID #3772: Add the anomaly_id to the http_alerter json

- Add the real anomalyScore to the http alert

Modified:
skyline/mirage/mirage.py
skyline/mirage/mirage_alerters.py