### PR TITLE
get_cluster_data - wip

### DIFF
--- a/docs/panorama.rst
+++ b/docs/panorama.rst
@@ -10,7 +10,7 @@ pagerduty alerter.  Therefore having this set to ``True`` means that Panorama
 will record samples of **all** metrics that are flagged as anomalous.  Sampling
 at :mod:`settings.PANORAMA_EXPIRY_TIME`, the default is 900 seconds.  Although
 this may result in a lot of entries in the anomalies DB table, it is useful for
-helping with root cause analysis.
+helping with root cause analysis and correlations.
 
 New records are used to trigger further analysis of the metric population in
 Luminosity to analyse the metric population for cross correlations.  However,
@@ -19,40 +19,80 @@ metric anomalies are recorded.
 
 The :mod:`settings.PANORAMA_CHECK_MAX_AGE` ensures that Panorama only processes
 checks that are not older than this value.  This mitigates against Panorama
-stampeding against the MySQL database, if either Panorama or MySQL were stopped
-and there are a lot of Panorama check files queued to process.  If this is set
-to 0, Panorama will process all checks, regardless of age.
+stampeding against the MySQL database, if either Panorama or MariaDB/MySQL were
+stopped and there are a lot of Panorama check files queued to process.  If this
+is set to 0, Panorama will process all checks, regardless of age.
 
 There is a Panorama view in the Skyline Webapp frontend UI to allow you to
 search and view historic anomalies.
 
-Create a MySQL database
------------------------
+The skyline MariaDB/MySQL database
+----------------------------------
 
-You can install and run MySQL on the Skyline server or use any existing MySQL
-server to create the database on.  The Skyline server just has to be able to
-access the database with the user and password you configure in ``settings.py``
-:mod:`settings.PANORAMA_DBUSER` and :mod:`settings.PANORAMA_DBUSERPASS`
+You can install and run MariaDB/MySQL on the Skyline server itself or use any
+existing MariaDB/MySQL server to create the database on or use a Galera cluster.
+The Skyline server just has to be able to access the database with the user and
+password you configure in  ``settings.py`` :mod:`settings.PANORAMA_DBUSER` and
+:mod:`settings.PANORAMA_DBUSERPASS`
 
-.. note:: It is recommended, if possible that MySQL is configured to use a single
-  file per InnoDB table with the MySQL config option - ``innodb_file_per_table=1``
-  This is due to the fact that the anomalies and Ionosphere related MySQL tables
-  are InnoDB tables and all the other core Skyline DB tables are MyISAM.
-  If you are adding the Skyline DB to an existing MySQL database server please
-  consider the ramifications to your setup.  It is not a requirement, just a
-  tidier and more efficient way to run MySQL InnoDB tables in terms of
-  managing space allocations with InnoDB and it segregates databases from each
-  other in the context on the .ibd file spaces, making for easier management of
-  each individual database in terms of ibd file space.  However that was really
-  only an additional caution.  Retrospectively, it is unlikely that the
-  anomalies table will ever really be a major problem in terms of the page space
-  requirements any time soon.  It appears and it is hoped anyway, time and
-  really big data sets may invalidate this in the future, Gaia DR1 MySQL say :)
+Skyline has moved to MariaDB and although MySQL and MariaDB should be
+interoperable, MariaDB has recently departed from full MySQL compatibility so
+it is recommended that you use the official MariaDB-server rather than MySQL if
+possible.  Going forward Skyline will only be developed and tested against
+MariaDB.
 
-.. warning:: It is assumed that the database is not running with an offset and
-  the database increments ids by 1.  If you are running an offset please review
-  all SQL updates to determine if you need to change anything in the SQL when
-  you apply Skyline SQL updates.
+InnoDB tables
+^^^^^^^^^^^^^
+
+It is recommended, if possible that MariaDB/MySQL is configured to use a single
+file per InnoDB table with the MariaDB/MySQL config option -
+``innodb_file_per_table=1``.  This is due to the fact that the anomalies and
+Ionosphere related MariaDB/MySQL tables are InnoDB tables and all the other
+core Skyline DB tables are MyISAM.
+
+The MyISAM storage engine is used for the metadata type tables because it is
+a simpler structure and faster for data which is often queried and FULL TEXT
+searching.
+
+The InnoDB storage engine is used for the anomaly table - mostly writes.
+z_fp_ tables are InnoDB tables and each metric that has an Ionosphere features
+profile created (e.g. has been trained) has a z_fp_<metric_id> and a
+z_ts_<metric_id> table created, therefore if you have 10000 metrics and you
+created features profiles (trained) for each one, there would be 20000 tables.
+Bear in mind, that not all metrics will have features profiles created as you
+have to manually train to create each one.
+
+If you are adding the Skyline database to an existing MariaDB/MySQL database
+server please consider the ramifications to your set up.  It is not a
+requirement, just a tidier and more efficient way to run MariaDB/MySQL InnoDB
+tables in terms of managing space allocations with InnoDB and it segregates
+databases from each other in the context on the .ibd file spaces, making for
+easier management of each individual database in terms of ibd file space.
+However that was really only an additional caution.  Retrospectively, it is
+unlikely that the anomalies table will ever really be a major problem in terms
+of the page space requirements any time soon.
+
+MyISAM and InnoDB or InnoDB only
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The default Skyline database schema is designed for optimum performance
+through the use of MyISAM and InnoDB tables where appropriate for the data and
+table usage.  However the Skyline database can be run with InnoDB only tables.
+The small performance loss that may result from not using the MyISAM tables
+where appropriate is gained in the ability to run the database on a MariaDB
+Galera cluster to achieve high availability and resilience on the database.
+If you wish to use InnoDB tables only, see the lines to uncomment in the snippet
+below.
+
+ID offsets
+^^^^^^^^^^
+It is assumed that the database is not running with an offset and the database
+increments ids by 1.  If you are running an offset please review all SQL updates
+to determine if you need to change anything in the SQL when you apply Skyline
+SQL updates.  Although it is highly unlikely to ever need to be considered.
+
+Create the skyline MariaDB/MySQL database
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - See ``skyline.sql`` in your cloned Skyline repo for the schema creation script
   and create the skyline database (also create a user with permissions on the
@@ -60,8 +100,17 @@ access the database with the user and password you configure in ``settings.py``
 
 .. code-block:: bash
 
-    mysql -u root -p < /opt/skyline/github/skyline/skyline/skyline.sql
-    mysql -u root -p -e "GRANT ALL ON skyline.* TO 'skyline'@'localhost' IDENTIFIED BY '$YOUR_MYSQL_SKYLINE_PASSWORD' \
+    # IF YOU WISH TO USE INNODB TABLES ONLY UNCOMMENT THE FOLLOWING LINES
+    # For Galera clustering
+    #cp /opt/skyline/github/skyline/skyline/skyline.sql /opt/skyline/github/skyline/skyline/skyline.myisam.sql
+    #cat /opt/skyline/github/skyline/skyline/skyline.myisam.sql | sed -e 's/MyISAM/InnoDB/g' > /opt/skyline/github/skyline/skyline/skyline.sql
+
+    # Note if you are using MariaDB on the database host, the password is longer
+    # required for the root user.  If you are using MySQL use password as
+    # appropriate
+    mysql -u root < /opt/skyline/github/skyline/skyline/skyline.sql
+    # Example permissions, change localhost to as appropriate for your set up
+    mysql -u root -e "GRANT ALL ON skyline.* TO 'skyline'@'localhost' IDENTIFIED BY '$YOUR_MYSQL_SKYLINE_PASSWORD' \
     FLUSH PRIVILEGES;"
 
 - Enable Panorama and review the other Panorama settings in ``settings.py``

--- a/docs/running-multiple-skylines.rst
+++ b/docs/running-multiple-skylines.rst
@@ -37,9 +37,9 @@ these.
 
 The following settings pertain to running multiple Skyline instances:
 
-- :mod:`settings.ALTERNATIVE_SKYLINE_URLS`
-- :mod:`settings.REMOTE_SKYLINE_INSTANCES`
-- :mod:`settings.HORIZON_SHARDS`
+- :mod:`settings.ALTERNATIVE_SKYLINE_URLS` [required]
+- :mod:`settings.REMOTE_SKYLINE_INSTANCES` [required]
+- :mod:`settings.HORIZON_SHARDS` [optional]
 
 With the introduction of Luminosity a requirement for Skyline to pull the time
 series data from remote Skyline instances was added to allow for cross
@@ -48,6 +48,28 @@ endpoint and preprocesses the time series data for Luminosity on the remote
 Skyline instance and returns only the fragments (gzipped) of time series
 required for analysis, by default the previous 12 minutes, to minimise bandwidth
 and ensure performance is maintained.
+
+Running Skyline in any form of clustered configuration requires that each
+Skyline instance know about the other instances and has access to them via the
+appropriate firewall or network rules and via the reverse proxy configuration
+(Apache or nginx).
+
+:mod:`settings.ALTERNATIVE_SKYLINE_URLS` is a reequired list of alternative URLs
+for the other nodes in the Skyline cluster, so that if a request is made to the
+Skyline webapp for a resource it does not have, it can return the other URLs to
+the client.
+
+:mod:`settings.REMOTE_SKYLINE_INSTANCES` is similar but is this is used by
+Skyline internally to request resources from other Skyline instances to:
+
+1. Retrieve time series data and general data for metrics served by the other
+  Skyline instance/s.
+2. To retrieve resources for certain client and API requests to respond with
+  all the data for the cluster, in terms of unique_metrics, alerting_metrics,
+  etc.
+
+Read about :mod:`settings.HORIZON_SHARDS` see
+`HORIZON_SHARDS <horizon.html#HORIZON_SHARDS>`__ section on the Horizon page.
 
 Hot standby configuration
 -------------------------

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -2054,8 +2054,28 @@ Webapp settings
 WEBAPP_SERVER = 'gunicorn'
 """
 :var WEBAPP_SERVER: Run the Webapp via gunicorn (recommended) or the Flask
-    development server, set this to either ``'gunicorn'`` or ``'flask'``
+    development server, set this to either ``'gunicorn'`` or ``'flask'``.
+    Flask is no longer supported.
 :vartype WEBAPP_SERVER: str
+"""
+
+WEBAPP_GUNICORN_WORKERS = 4
+"""
+:var WEBAPP_GUNICORN_WORKERS: How many gunicorn workers to run for the webapp.
+    The normal recommended value for gunicorn is generally be between 2-4
+    workers per core, however on a machine with lots of cores this is probably
+    over provisioning for the webapp, depending on the load on the server.
+:vartype WEBAPP_GUNICORN_WORKERS: int
+"""
+
+WEBAPP_GUNICORN_BACKLOG = 254
+"""
+:var WEBAPP_GUNICORN_BACKLOG: The maximum number of pending connections.  This
+    refers to the number of clients that can be waiting to be served. Exceeding
+    this number results in the client getting an error when attempting to
+    connect. It should only affect servers under significant load.  It must be a
+    positive integer. Generally set in the 64-2048 range.
+:vartype WEBAPP_GUNICORN_BACKLOG: int
 """
 
 WEBAPP_IP = '127.0.0.1'

--- a/skyline/webapp/gunicorn.py
+++ b/skyline/webapp/gunicorn.py
@@ -10,9 +10,19 @@ sys.path.insert(0, os.path.dirname(__file__))
 import settings
 
 bind = '%s:%s' % (settings.WEBAPP_IP, str(settings.WEBAPP_PORT))
+# @modified 20201011 - Reduce the number of workers on machine with lots of
+#                      CPUs
 # workers = multiprocessing.cpu_count() * 2 + 1
-workers = 2
-backlog = 10
+# workers = 2
+# backlog = 10
+try:
+    workers = settings.WEBAPP_GUNICORN_WORKERS
+except:
+    workers = 4
+try:
+    backlog = settings.WEBAPP_GUNICORN_BACKLOG
+except:
+    backlog = 254
 
 skyline_app = 'webapp'
 skyline_app_logger = '%sLog' % skyline_app


### PR DESCRIPTION
IssueID #3824: get_cluster_data
IssueID #3820: HORIZON_SHARDS

- Added the get_cluster_data function to enable api requests to get data from
  the /api of REMOTE_SKYLINE_INSTANCES.  This allows the user to query a single
  Skyline webapp node in a cluster and the Skyline instance will respond with
  the concentated responses of all the REMOTE_SKYLINE_INSTANCES in one a single
  response.
- Added the cluster_data argument to api methods that can require data from the
  cluster in the response
- Changed default rebrow page from Server to Keys
- Added WEBAPP_GUNICORN_WORKERS and WEBAPP_GUNICORN_BACKLOG to settings and in
  gunicorn.py
- Updated docs on cluster aspects

Modified:
docs/panorama.rst
docs/running-multiple-skylines.rst
skyline/settings.py
skyline/webapp/backend.py
skyline/webapp/gunicorn.py
skyline/webapp/webapp.py