### PR TITLE
get_cluster_data handle in luminosity_remote_data

### DIFF
--- a/skyline/ionosphere/layers.py
+++ b/skyline/ionosphere/layers.py
@@ -396,7 +396,10 @@ def run_layer_algorithms(base_name, layers_id, timeseries, layers_count, layers_
             if e_boundary_percent_tolerance:
                 try:
                     e_boundary_limit_tolerance = int(math.ceil((e_boundary_limit / 100.0) * e_boundary_percent_tolerance))
-                    e_boundary_limit = e_boundary_limit - e_boundary_limit_tolerance
+                    # @modified 20201112 - Feature #2558: Ionosphere - fluid approximation - approximately_close on layers
+                    # Correct sign of e_boundary_limit where e_condition == '<' or '<='
+                    # e_boundary_limit = e_boundary_limit - e_boundary_limit_tolerance
+                    e_boundary_limit = e_boundary_limit + e_boundary_limit_tolerance
                     logger.info(
                         'layers :: subtracted a tolerance of %s to E layer boundary limit of %s, e_boundary_limit now %s' % (
                             str(e_boundary_limit_tolerance),

--- a/skyline/webapp/backend.py
+++ b/skyline/webapp/backend.py
@@ -571,6 +571,14 @@ def luminosity_remote_data(anomaly_timestamp):
         # Convert the time series if this is a known_derivative_metric
         # @modified 20200728 - Bug #3652: Handle multiple metrics in base_name conversion
         # base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
+
+        # @added 20201117 - Feature #3824: get_cluster_data
+        #                   Feature #2464: luminosity_remote_data
+        #                   Bug #3266: py3 Redis binary objects not strings
+        #                   Branch #3262: py3
+        # Convert metric_name bytes to str
+        metric_name = str(metric_name)
+
         if metric_name.startswith(settings.FULL_NAMESPACE):
             base_name = metric_name.replace(settings.FULL_NAMESPACE, '', 1)
         else:


### PR DESCRIPTION
IssueID #3824: get_cluster_data
IssueID #2464: luminosity_remote_data
IssueID #3266: py3 Redis binary objects not strings
IssueID #3262: py3
IssueID #2558: Ionosphere - fluid approximation - approximately_close on layers
IssueID #3756: LUMINOSITY_CORRELATION_MAPS

- Convert metric_name bytes to str in backend.py and wrapped luminosity_remote_data
  in try and added more logging to webapp.py (3824, 2464, 3266, 3262)
- Correct sign of e_boundary_limit where e_condition == '<' or '<=' (2558)
- Added LUMINOSITY_CORRELATION_MAPS - WIP to process_correlations.py (3756) and
  use correct url with api for get_cluster_data (3756)

Modified:
skyline/ionosphere/layers.py
skyline/luminosity/process_correlations.py
skyline/webapp/backend.py
skyline/webapp/webapp.py