### PR TITLE
HORIZON_SHARDS

### DIFF
--- a/bin/flux.d
+++ b/bin/flux.d
@@ -176,12 +176,16 @@ start () {
 
     if [ $USE_VIRTUALENV -eq 0 ]; then
       cd "$BASEDIR/skyline/${SERVICE_NAME}"
-      gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" flux &
+      # @modified 20201121 - Feature #3820: HORIZON_SHARDS
+      # Added gunicorn timeout
+      gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" flux --timeout 120 &
     else
       cd "$BASEDIR/skyline/${SERVICE_NAME}"
       PYTHON_VIRTUALENV_BIN_DIR=$(dirname $USE_PYTHON)
       source "$PYTHON_VIRTUALENV_BIN_DIR/activate"
-      gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" flux &
+      # @modified 20201121 - Feature #3820: HORIZON_SHARDS
+      # Added gunicorn timeout
+      gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" flux --timeout 120 &
     fi
     RETVAL=$?
 

--- a/bin/webapp.d
+++ b/bin/webapp.d
@@ -190,7 +190,9 @@ start () {
       fi
       if [ "$WEBAPP_SERVER" == "gunicorn" ]; then
         cd "$BASEDIR/skyline/${SERVICE_NAME}"
-        gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" webapp:app &
+        # @modified 20201121 - Feature #3820: HORIZON_SHARDS
+        # Added gunicorn timeout
+        gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" webapp:app --timeout 120 &
       fi
     else
       if [ "$WEBAPP_SERVER" == "flask" ]; then
@@ -200,7 +202,9 @@ start () {
         cd "$BASEDIR/skyline/${SERVICE_NAME}"
         PYTHON_VIRTUALENV_BIN_DIR=$(dirname $USE_PYTHON)
         source "$PYTHON_VIRTUALENV_BIN_DIR/activate"
-        gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" webapp:app &
+        # @modified 20201121 - Feature #3820: HORIZON_SHARDS
+        # Added gunicorn timeout
+        gunicorn --config "$BASEDIR/skyline/${SERVICE_NAME}/gunicorn.py" webapp:app --timeout 120 &
       fi
     fi
     RETVAL=$?

--- a/skyline/horizon/listen.py
+++ b/skyline/horizon/listen.py
@@ -240,7 +240,7 @@ class Listen(Process):
                 logger.info('%s :: listening over tcp for pickles on %s' % (skyline_app, str(self.port)))
 
                 (conn, address) = s.accept()
-                logger.info('%s :: connection from %s:%s' % (skyline_app, str(address[0]), str(self.port)))
+                logger.info('%s :: connection from %s on %s' % (skyline_app, str(address[0]), str(self.port)))
 
                 chunk = []
                 while 1:

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -1366,6 +1366,17 @@ Shard are 0 indexed.
 
 """
 
+HORIZON_SHARD_PICKLE_PORT = 2026
+"""
+:var HORIZON_SHARD_PICKLE_PORT: ADVANCED FEATURE - This is the port that listens
+    for Graphite pickles over TCP, sent by Graphite's carbon-relay-b agent.
+    When running Skyline clustered with multiple Horizon instances, an
+    additional Graphite carbon-relay-b instances are required to be run to on
+    the remote Graphite servrs to forward metrics on to the remote Horizons.
+    See https://earthgecko-skyline.readthedocs.io/en/latest/horizon.html#horizon-shards
+:vartype PICKLE_PORT: str
+"""
+
 HORIZON_SHARD_DEBUG = False
 """
 :var HORIZON_SHARD_DEBUG: For development only to log some sharding debug info


### PR DESCRIPTION
IssueID #3820: HORIZON_SHARDS

- Added gunicorn timeout to webapp and flux bins
- Add an additional listen process on a different port for the shard on horizon
- Added horizon.shards.metrics_assigned, horizon.shards.metrics_dropped and
  aet.horizon.metrics_received Redis sets to worker for debug purposes
- Added HORIZON_SHARD_PICKLE_PORT to settings

Modified:
bin/flux.d
bin/webapp.d
skyline/horizon/agent.py
skyline/horizon/listen.py
skyline/horizon/worker.py
skyline/settings.py