### PR TITLE
custom_algorithms - run_before_3sigma parameter

### DIFF
--- a/docs/alerts.rst
+++ b/docs/alerts.rst
@@ -5,7 +5,7 @@ Alerts
 Alerts in Skyline are configured via two sets of settings.  There are the
 Analyzer (Mirage and Ionosphere) related settings and the Boundary related
 alert settings.  This is due to the two classes of alerts being different,
-with Analzyer, Mirage and Ionosphere alerts being related to anomalies and
+with Analyzer, Mirage and Ionosphere alerts being related to anomalies and
 Boundary alerts being related to breaches of the static and dynamic thresholds
 defined for Boundary metrics.
 
@@ -75,8 +75,10 @@ the alerter:
 Analyzer, Mirage and Ionosphere related alert settings (anomaly detection) are:
 
 - :mod:`settings.ENABLE_ALERTS` - must be set to `True` to enable alerting
-- :mod:`settings.ENABLE_FULL_DURATION_ALERTS` - must be set to `True` to enable
-  Analyzer to alert
+- :mod:`settings.ENABLE_FULL_DURATION_ALERTS` - should be set to `False` if
+  enable Mirage is enabled.  If this is set to ``True`` Analyzer will alert
+  on all checks sent to Mirage, even if Mirage does not find them anomalous,
+  this is mainly for testing.
 - :mod:`settings.ALERTS` - must be defined to enable alerts via Analyzer and
   Mirage
 - :mod:`settings.SMTP_OPTS` - must be defined

--- a/skyline/custom_algorithms_to_run.py
+++ b/skyline/custom_algorithms_to_run.py
@@ -85,6 +85,17 @@ def get_custom_algorithms_to_run(current_skyline_app, base_name, custom_algorith
                 run_3sigma_algorithms = custom_algorithms[custom_algorithm]['run_3sigma_algorithms']
             except:
                 run_3sigma_algorithms = True
+
+            # @added 20201125 - Feature #3848: custom_algorithms - run_before_3sigma parameter
+            try:
+                run_before_3sigma = custom_algorithms[custom_algorithm]['run_before_3sigma']
+            except:
+                run_before_3sigma = True
+            try:
+                run_only_if_consensus = custom_algorithms[custom_algorithm]['run_only_if_consensus']
+            except:
+                run_only_if_consensus = False
+
             try:
                 use_with = custom_algorithms[custom_algorithm]['use_with']
             except:
@@ -116,6 +127,9 @@ def get_custom_algorithms_to_run(current_skyline_app, base_name, custom_algorith
                     #                   Task #3744: POC matrixprofile
                     # Added missing run_3sigma_algorithms
                     'run_3sigma_algorithms': run_3sigma_algorithms,
+                    # @added 20201125 - Feature #3848: custom_algorithms - run_before_3sigma parameter
+                    'run_before_3sigma': run_before_3sigma,
+                    'run_only_if_consensus': run_only_if_consensus,
                     'use_with': use_with,
                 }
                 if debug:

--- a/skyline/horizon/worker.py
+++ b/skyline/horizon/worker.py
@@ -451,7 +451,7 @@ class Worker(Process):
                     self.redis_conn.sadd('horizon.metrics_received', *set(metrics_received))
                 except:
                     logger.error(traceback.format_exc())
-                    logger.error('%s :: error adding horizon.metrics_received: %s' % (skyline_app, str(e)))
+                    logger.error('%s :: error adding horizon.metrics_received' % (skyline_app))
                 if self.canary:
                     try:
                         logger.info('renaming key horizon.metrics_received to aet.horizon.metrics_received')

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -728,6 +728,8 @@ CUSTOM_ALGORITHMS = {}
             'consensus': 6,
             'algorithms_allowed_in_consensus': [],
             'run_3sigma_algorithms': True,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
             'use_with': ['analyzer', 'analyzer_batch', 'mirage', 'crucible'],
             'debug_logging': False,
         },
@@ -744,6 +746,8 @@ CUSTOM_ALGORITHMS = {}
             'consensus': 6,
             'algorithms_allowed_in_consensus': [],
             'run_3sigma_algorithms': True,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
             # This does not run on analyzer as it is weekly data
             'use_with': ['mirage', 'crucible'],
             'debug_logging': False,
@@ -757,6 +761,8 @@ CUSTOM_ALGORITHMS = {}
             'consensus': 1,
             'algorithms_allowed_in_consensus': ['detect_significant_change'],
             'run_3sigma_algorithms': False,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
             'use_with': ['analyzer', 'crucible'],
             'debug_logging': True,
         },
@@ -768,6 +774,8 @@ CUSTOM_ALGORITHMS = {}
             'consensus': 1,
             'algorithms_allowed_in_consensus': ['matrixprofile'],
             'run_3sigma_algorithms': False,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
             'use_with': ['snab'],
             'debug_logging': False,
         },
@@ -796,7 +804,18 @@ CUSTOM_ALGORITHMS = {}
 :param run_3sigma_algorithms: a boolean stating whether to run normal 3 sigma
     algorithms, this is optional and defaults to ``True`` if it is not passed
     in the dictionary.  Read the full documentation referred to above to
-    determine the affects of passing this as ``False``.
+    determine the effects of passing this as ``False``.
+: param run_before_3sigma: a boolean stating whether to run the custom algorithm
+  before the normal three-sigma algorithms, this defaults to ``True``.  If you
+  want your custom algorithm to run after the three-sigma algorithms set this to
+  ``False``.  Read the full documentation referred to above to determine the
+    effects of passing this as ``False``.
+:param run_only_if_consensus: a boolean stating whether to run the custom
+    algorithm only if CONSENSUS or MIRAGE_CONSENSUS is achieved, it defaults to
+    ``False``.  This only applies to custom algorithms that are run after
+    three-sigma algorithms, e.g. with the parameter ``run_before_3sigma: False``
+    Currently this parameter only uses the CONSENSUS or MIRAGE_CONSENSUS setting
+    and does not apply the consensus parameter above.
 :param use_with: a list of Skyline apps which should apply the algorithm if
     they handle the metric, it is only applied if the app handles the metric,
     generally set this to ``['analyzer', 'analyzer_batch', 'mirage', 'crucible']``
@@ -808,7 +827,9 @@ CUSTOM_ALGORITHMS = {}
 :type algorithm_parameters: dict
 :type consensus: int
 :type algorithms_allowed_in_consensus: list
+:type run_before_3sigma: boolean
 :type run_3sigma_algorithms: boolean
+:type run_only_if_consensus: boolean
 :type use_with: list
 :type debug_logging: boolean
 

--- a/skyline/webapp/templates/crucible_process_metrics.html
+++ b/skyline/webapp/templates/crucible_process_metrics.html
@@ -99,11 +99,11 @@ function validate_to_process_submission()
   		      </tr>
   		      <tr>
               <td>from_timestamp</td>
-              <td><input type="number" name="from_timestamp" value="" /> unix timestamp</td>
+              <td><input type="number" name="from_timestamp" value="" /> [required] unix timestamp</td>
   		      </tr>
   		      <tr>
               <td>until_timestamp</td>
-              <td><input type="number" name="until_timestamp" value="" /> unix timestamp</td>
+              <td><input type="number" name="until_timestamp" value="" /> [required] unix timestamp</td>
   		      </tr>
 <!--        # @added 20200422 - Feature #3500: webapp - crucible_process_metrics
             #                   Feature #1448: Crucible web UI
@@ -161,10 +161,6 @@ function validate_to_process_submission()
 <code>histogram_bins,first_hour_average,stddev_from_average,grubbs,ks_test,mean_subtraction_cumulation,median_absolute_deviation,stddev_from_moving_average,least_squares</code><br>
 or <code>detect_drop_off_cliff</code> or <code>ks_test,detect_drop_off_cliff</code>, etc</td>
   		      </tr>
-        algorithms = settings.ALGORITHMS
-        if run_algorithms:
-            algorithms = run_algorithms
-
   		    </tbody>
   		  </table>
         <br>


### PR DESCRIPTION
IssueID #3848: custom_algorithms - run_before_3sigma parameter

- Added the run_before_3sigma and run_only_if_consensus parameters to
  custom_algorithms (mirage only)
- A custom_algorithm can now be run after three-sigma algorithms only if they
  reach CONSENSUS
- Tidied up some docs and typos

Modified:
docs/alerts.rst
docs/algorithms/custom-algorithms.rst
skyline/custom_algorithms_to_run.py
skyline/horizon/worker.py
skyline/mirage/mirage_algorithms.py
skyline/settings.py
skyline/webapp/templates/crucible_process_metrics.html