### PR TITLE
get_cluster_data fixes

### DIFF
--- a/skyline/webapp/backend.py
+++ b/skyline/webapp/backend.py
@@ -747,10 +747,10 @@ def get_cluster_data(api_endpoint, data_required, endpoint_params={}):
                 except:
                     logger.error(traceback.format_exc())
                     logger.error('error :: get_cluster_data :: failed to build remote_data from %s on %s' % (
-                        data_required, str(item)))
+                        str(data_required), str(item)))
             if remote_data:
-                logger.info('get_cluster_data :: got %s %s from %s on %s' % (
-                    str(len(remote_data)), data_required, str(item[0])))
+                logger.info('get_cluster_data :: got %s %s from %s' % (
+                    str(len(remote_data)), str(data_required), str(item[0])))
                 data = data + remote_data
 
     return data

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -1235,7 +1235,11 @@ def api():
             if remote_training_data:
                 logger.info('got %s remote metrics training data instances from the remote Skyline instances' % str(len(remote_training_data)))
                 remote_training_data_list = training_data + remote_training_data
-                training_data = list(set(remote_training_data_list))
+                # @modified 20201126 - Feature #3824: get_cluster_data
+                # set cannot be used here as each training data item includes a
+                # list which is unhashable
+                # training_data = list(set(remote_training_data_list))
+                training_data = remote_training_data_list
 
         data_dict = {"status": {}, "data": {"metrics": training_data}}
         return jsonify(data_dict), 200


### PR DESCRIPTION
IssueID #3824: get_cluster_data

- set cannot be used on all training_data as each item includes a list which is
  unhashable
- typo in log string

Modified:
skyline/webapp/backend.py
skyline/webapp/webapp.py