### PR TITLE
Add origin and shard to alerts

### DIFF
--- a/skyline/analyzer/analyzer.py
+++ b/skyline/analyzer/analyzer.py
@@ -3626,7 +3626,7 @@ class Analyzer(Thread):
                     logger.error('error :: failed to set analyzer.last_all_alerts Redis key')
             if str(all_alerts_set) != str(last_all_alerts_set):
                 logger.info('alert settings have changed alerts will be refreshed, reset current smtp_alerter_metrics list')
-                refresh_redis_alert_sets = True
+                # refresh_redis_alert_sets = True
 
             # @modified 20190518 - Bug #3020: Newly installed analyzer on docker not flushing and recreating analyzer algorithm exception Redis sets
             # The management of the analyzer Redis algorithm exception sets
@@ -5400,7 +5400,6 @@ class Analyzer(Thread):
                     except:
                         logger.error(traceback.format_exc())
                         logger.error('error :: failed to remove %s to Redis set %s' % (str(metric_to_remove), remove_training_data_redis_set))
-
 
             # @added 20200611 - Feature #3578: Test alerts
             # @modified 20200625 - Feature #3578: Test alerts

--- a/skyline/mirage/mirage_alerters.py
+++ b/skyline/mirage/mirage_alerters.py
@@ -53,6 +53,9 @@ from time import sleep
 
 from email import charset
 
+# @added 20201127 - Feature #3820: HORIZON_SHARDS
+from os import uname
+
 # @modified 20160820 - Issue #23 Test dependency updates
 # Use Agg for matplotlib==1.5.2 upgrade, backwards compatibile
 import matplotlib
@@ -120,6 +123,16 @@ try:
     SNAB_ENABLED = settings.SNAB_ENABLED
 except:
     SNAB_ENABLED = False
+
+# @added 20201127 - Feature #3820: HORIZON_SHARDS
+try:
+    HORIZON_SHARDS = settings.HORIZON_SHARDS.copy()
+except:
+    HORIZON_SHARDS = {}
+this_host = str(uname()[1])
+HORIZON_SHARD = 0
+if HORIZON_SHARDS:
+    HORIZON_SHARD = HORIZON_SHARDS[this_host]
 
 skyline_app = 'mirage'
 skyline_app_logger = '%sLog' % skyline_app
@@ -1660,6 +1673,11 @@ def alert_slack(alert, metric, second_order_resolution_seconds, context):
             # initial_comment = slack_title + ' :: <' + link  + '|graphite image link>'
             initial_comment = slack_title + ' :: <' + link + '|graphite image link>\nFor anomaly at ' + slack_time_string
 
+        # @added 20201127 - Feature #3820: HORIZON_SHARDS
+        # Add the origin and shard for debugging purposes
+        if HORIZON_SHARDS:
+            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + HORIZON_SHARD + ')'
+
         # @added 20200929 - Task #3748: POC SNAB
         #                   Branch #3068: SNAB
         # Determine the anomaly and snab ids so that the tP, fP, tN, fN links
@@ -2184,7 +2202,12 @@ def alert_http(alert, metric, second_order_resolution_seconds, context):
             # Add the token as an independent entity from the alert
             # alert_data_dict = {"status": {}, "data": {"alert": metric_alert_dict}}
             alerter_token_str = str(alerter_token)
-            alert_data_dict = {"status": {}, "data": {"token": alerter_token_str, "alert": metric_alert_dict}}
+            # @modified 20201127 - Feature #3820: HORIZON_SHARDS
+            # Add the origin and shard to status for debugging purposes
+            if not HORIZON_SHARDS:
+                alert_data_dict = {"status": {}, "data": {"token": alerter_token_str, "alert": metric_alert_dict}}
+            else:
+                alert_data_dict = {"status": {"origin": this_host, "shard": HORIZON_SHARD}, "data": {"token": alerter_token_str, "alert": metric_alert_dict}}
             logger.info('alert_http :: alert_data_dict to send - %s' % str(alert_data_dict))
             # Allow requests to send as json
             # alert_data = json.dumps(alert_data_dict)

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -1236,7 +1236,7 @@ def api():
                 logger.info('got %s remote metrics training data instances from the remote Skyline instances' % str(len(remote_training_data)))
                 remote_training_data_list = training_data + remote_training_data
                 # @modified 20201126 - Feature #3824: get_cluster_data
-                # set cannot be used here as each training data item includes a
+                # set cannot be used here as each training_data item includes a
                 # list which is unhashable
                 # training_data = list(set(remote_training_data_list))
                 training_data = remote_training_data_list


### PR DESCRIPTION
IssueID #3820: HORIZON_SHARDS

- Added origin host and shard to slack and http_alert status if the alert comes
  from a cluster server

Modified:
skyline/analyzer/alerters.py
skyline/analyzer/analyzer.py
skyline/analyzer/alerters.py
skyline/boundary/boundary_alerters.py
skyline/mirage/mirage_alerters.py
skyline/webapp/webapp.py