### PR TITLE
HORIZON_SHARDS and get_cluster_data related changes

### DIFF
--- a/skyline/analyzer/alerters.py
+++ b/skyline/analyzer/alerters.py
@@ -1888,7 +1888,7 @@ def alert_slack(alert, metric, context):
         # @added 20201127 - Feature #3820: HORIZON_SHARDS
         # Add the origin and shard for debugging purposes
         if HORIZON_SHARDS:
-            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + HORIZON_SHARD + ')'
+            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + str(HORIZON_SHARD) + ')'
 
         add_to_panorama = True
         try:

--- a/skyline/boundary/boundary_alerters.py
+++ b/skyline/boundary/boundary_alerters.py
@@ -880,7 +880,7 @@ def alert_slack(datapoint, metric_name, expiration_time, metric_trigger, algorit
         # @added 20201127 - Feature #3820: HORIZON_SHARDS
         # Add the origin and shard for debugging purposes
         if HORIZON_SHARDS:
-            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + HORIZON_SHARD + ')'
+            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + str(HORIZON_SHARD) + ')'
 
         try:
             # slack does not allow embedded images, nor links behind authentication

--- a/skyline/mirage/mirage_alerters.py
+++ b/skyline/mirage/mirage_alerters.py
@@ -1676,7 +1676,7 @@ def alert_slack(alert, metric, second_order_resolution_seconds, context):
         # @added 20201127 - Feature #3820: HORIZON_SHARDS
         # Add the origin and shard for debugging purposes
         if HORIZON_SHARDS:
-            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + HORIZON_SHARD + ')'
+            initial_comment = initial_comment + ' - from ' + this_host + ' (shard ' + str(HORIZON_SHARD) + ')'
 
         # @added 20200929 - Task #3748: POC SNAB
         #                   Branch #3068: SNAB


### PR DESCRIPTION
IssueID #3820: HORIZON_SHARDS
IssueID #3824: get_cluster_data

- Correct shard type to slack and http_alert
- Added cluster_data element to response status
- Determine which remote Skyline host the metric is assigned to and return the
  client a redirect to the remote Skyline instance that will have the ionosphere
  training data for the metric

Modified:
skyline/analyzer/alerters.py
skyline/boundary/boundary_alerters.py
skyline/mirage/mirage_alerters.py
skyline/webapp/backend.py
skyline/webapp/webapp.py