### PR TITLE
Handle boring sparsely populated metrics in derivative_metrics

### DIFF
--- a/skyline/boundary/boundary.py
+++ b/skyline/boundary/boundary.py
@@ -141,6 +141,9 @@ class Boundary(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     def unique_noHash(self, seq):

--- a/skyline/crucible/crucible.py
+++ b/skyline/crucible/crucible.py
@@ -130,6 +130,9 @@ class Crucible(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     # @added 20200327 - Branch #3262: py3

--- a/skyline/flux/populate_metric_worker.py
+++ b/skyline/flux/populate_metric_worker.py
@@ -129,6 +129,9 @@ class PopulateMetricWorker(Process):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def run(self):

--- a/skyline/flux/uploaded_data_worker.py
+++ b/skyline/flux/uploaded_data_worker.py
@@ -98,6 +98,9 @@ class UploadedDataWorker(Process):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def run(self):

--- a/skyline/flux/worker.py
+++ b/skyline/flux/worker.py
@@ -153,6 +153,9 @@ class Worker(Process):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def run(self):

--- a/skyline/horizon/listen.py
+++ b/skyline/horizon/listen.py
@@ -223,6 +223,9 @@ class Listen(Process):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     def listen_pickle(self):

--- a/skyline/horizon/roomba.py
+++ b/skyline/horizon/roomba.py
@@ -96,6 +96,9 @@ class Roomba(Thread):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def vacuum(self, i, namespace, duration):

--- a/skyline/horizon/worker.py
+++ b/skyline/horizon/worker.py
@@ -112,6 +112,9 @@ class Worker(Process):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def in_skip_list(self, metric_name):

--- a/skyline/ionosphere/ionosphere.py
+++ b/skyline/ionosphere/ionosphere.py
@@ -284,6 +284,9 @@ class Ionosphere(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     """

--- a/skyline/luminosity/luminosity.py
+++ b/skyline/luminosity/luminosity.py
@@ -184,6 +184,9 @@ class Luminosity(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     def mysql_insert(self, insert):
@@ -316,7 +319,7 @@ class Luminosity(Thread):
         try:
             self.redis_conn.sadd(redis_set, data)
         except:
-            logger.info(traceback.format_exc())
+            logger.error(traceback.format_exc())
             logger.error('error :: failed to add %s to Redis set %s' % (
                 str(data), str(redis_set)))
         redis_set = 'luminosity.runtimes'
@@ -324,7 +327,7 @@ class Luminosity(Thread):
         try:
             self.redis_conn.sadd(redis_set, data)
         except:
-            logger.info(traceback.format_exc())
+            logger.error(traceback.format_exc())
             logger.error('error :: failed to add %s to Redis set %s' % (
                 str(data), str(redis_set)))
 
@@ -353,7 +356,8 @@ class Luminosity(Thread):
         correlations_shifted_too_far = 0
         if sorted_correlations:
             logger.info('number of correlations shifted too far - %s' % str(correlations_shifted_too_far))
-            logger.info('sorted_correlations :: %s' % str(sorted_correlations))
+            if LOCAL_DEBUG or ENABLE_LUMINOSITY_DEBUG:
+                logger.debug('debug :: sorted_correlations :: %s' % str(sorted_correlations))
             luminosity_correlations = []
             for metric, coefficient, shifted, shifted_coefficient in sorted_correlations:
                 for metric_id, metric_name in correlated_metrics_list:
@@ -383,7 +387,7 @@ class Luminosity(Thread):
                     try:
                         self.redis_conn.sadd(redis_set, data)
                     except:
-                        logger.info(traceback.format_exc())
+                        logger.error(traceback.format_exc())
                         logger.error('error :: failed to add %s to Redis set %s' % (
                             str(data), str(redis_set)))
 
@@ -416,7 +420,8 @@ class Luminosity(Thread):
         if luminosity_populated:
             logger.info('%s correlations added to database for %s anomaly id %s' % (
                 str(number_of_correlations_in_insert), base_name, str(anomaly_id)))
-            logger.info('values_string :: %s' % str(values_string))
+            if LOCAL_DEBUG or ENABLE_LUMINOSITY_DEBUG:
+                logger.debug('debug :: values_string :: %s' % str(values_string))
 
         return luminosity_populated
 

--- a/skyline/mirage/mirage.py
+++ b/skyline/mirage/mirage.py
@@ -258,6 +258,9 @@ class Mirage(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     def spawn_alerter_process(self, alert, metric, second_order_resolution_seconds, context):

--- a/skyline/panorama/panorama.py
+++ b/skyline/panorama/panorama.py
@@ -200,6 +200,9 @@ class Panorama(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     """

--- a/skyline/snab/snab.py
+++ b/skyline/snab/snab.py
@@ -111,6 +111,9 @@ class SNAB(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     def spin_snab_process(self, i, check_details):

--- a/skyline/snab/snab_flux_load_test.py
+++ b/skyline/snab/snab_flux_load_test.py
@@ -86,6 +86,9 @@ class SNAB_flux_load_test(Thread):
             kill(self.current_pid, 0)
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent or current process dead')
             exit(0)
 
     def spin_snab_flux_load_test_process(self, current_timestamp):

--- a/skyline/vista/fetcher.py
+++ b/skyline/vista/fetcher.py
@@ -98,6 +98,9 @@ class Fetcher(Thread):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def fetch_process(self, i, metrics_to_fetch):

--- a/skyline/vista/worker.py
+++ b/skyline/vista/worker.py
@@ -91,6 +91,9 @@ class Worker(Process):
         try:
             kill(self.parent_pid, 0)
         except:
+            # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
+            # Log warning
+            logger.warn('warning :: parent process is dead')
             exit(0)
 
     def run(self):


### PR DESCRIPTION
IssueID #3856: Handle boring sparsely populated metrics in derivative_metrics

- Handle key not existing and exception on last_key_value if None in analyzer
- Adding warning log to all check_if_parent_is_alive functions
- Only log sorted_correlations and inserts in debug in luminosity

Modified:
skyline/analyzer/analyzer.py
skyline/boundary/boundary.py
skyline/crucible/crucible.py
skyline/flux/populate_metric_worker.py
skyline/flux/uploaded_data_worker.py
skyline/flux/worker.py
skyline/horizon/listen.py
skyline/horizon/roomba.py
skyline/horizon/worker.py
skyline/ionosphere/ionosphere.py
skyline/luminosity/luminosity.py
skyline/mirage/mirage.py
skyline/panorama/panorama.py
skyline/snab/snab.py
skyline/snab/snab_flux_load_test.py
skyline/vista/fetcher.py
skyline/vista/worker.py