### PR TITLE
luminosity - handle low frequency data and

### DIFF
--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -2777,7 +2777,7 @@ LUMINOSITY_CORRELATE_ALL = True
 """
 :var LUMINOSITY_CORRELATE_ALL: By default all metrics will be correlated with
     the entire metric population.
-:vartype LUMINOSITY_CORRELATE_NAMESPACES_ONLY: list
+:vartype LUMINOSITY_CORRELATE_ALL: boolean
 """
 
 LUMINOSITY_CORRELATE_NAMESPACES_ONLY = []
@@ -2786,9 +2786,12 @@ LUMINOSITY_CORRELATE_NAMESPACES_ONLY = []
     the same namespace should be correlated with.  The default is an empty list
     which results in all metrics being correlated with all metrics.  If
     namespaces are declared in the list, all metrics will be evaluated as to
-    whether they are in the list.  Metrics in the list will only be correlated
-    with metrics in the same namespace and excluded from correlations within
-    ANY other namespace, unless defined in the below
+    whether they are in the list.  Metrics will be evaluated against namespaces
+    in this list using :func:`.matched_or_regexed_in_list` which determines if a
+    pattern is in a list as a: 1) absolute match 2) match been dotted elements
+    3) matched by a regex. Metrics in the list will only be correlated with
+    metrics in the same namespace and excluded from correlations within ANY
+    other namespace, unless defined in the below
     mod:`settings.LUMINOSITY_CORRELATION_MAPS` method.
 :vartype LUMINOSITY_CORRELATE_NAMESPACES_ONLY: list
 

--- a/skyline/webapp/backend.py
+++ b/skyline/webapp/backend.py
@@ -491,7 +491,10 @@ def get_list(thing):
 
 
 # @added 20180720 - Feature #2464: luminosity_remote_data
-def luminosity_remote_data(anomaly_timestamp):
+# @modified 20201203 - Feature #3860: luminosity - handle low frequency data
+# Add the metric resolution
+# def luminosity_remote_data(anomaly_timestamp):
+def luminosity_remote_data(anomaly_timestamp, resolution):
     """
     Gets all the unique_metrics from Redis and then mgets Redis data for all
     metrics.  The data is then preprocessed for the remote Skyline luminosity
@@ -514,8 +517,12 @@ def luminosity_remote_data(anomaly_timestamp):
     # If you modify the values of 61 or 600 here, it must be modified in the
     # luminosity_remote_data function in
     # skyline/luminosity/process_correlations.py as well
-    from_timestamp = int(anomaly_timestamp) - 600
-    until_timestamp = int(anomaly_timestamp) + 61
+    # @modified 20201203 - Feature #3860: luminosity - handle low frequency data
+    # Use the metric resolution
+    # from_timestamp = int(anomaly_timestamp) - 600
+    # until_timestamp = int(anomaly_timestamp) + 61
+    from_timestamp = int(anomaly_timestamp) - (resolution * 10)
+    until_timestamp = int(anomaly_timestamp) + (resolution + 1)
 
     try:
         # @modified 20201123 - Feature #3824: get_cluster_data


### PR DESCRIPTION
IssueID #3860: luminosity - handle low frequency data

- Enable luminosity to dynamically handle varying metric resolutions and data
  that is of a lower frequency than 60 seconds automatically using the
  resolution of the data (best effort) to determine the offsets to use for cross
  correlation aanalysis.  This requires a change in process_correlations and to
  the /api?luminosity_remote_data functions in webapp and the backend to allow
  the resolution to be passed.

Modified:
skyline/luminosity/process_correlations.py
skyline/webapp/backend.py
skyline/webapp/webapp.py

IssueID #3858: skyline_functions - correlate_or_relate_with
IssueID #3740: webapp - anomaly API endpoint

- Added correlate_or_relate_with to skyline_functions
- Use correlate_or_relate_with in webapp /api?anomaly endpoint to filter
  correlations and related matches and anomalies that are in any correlation
  group/s that the metric belongs too
- Extend LUMINOSITY_CORRELATE_NAMESPACES_ONLY docstring in settings

Modified:
skyline/luminosity/process_correlations.py
skyline/settings.py
skyline/skyline_functions.py
skyline/webapp/backend.py
skyline/webapp/webapp.py