### PR TITLE
py 1.10.0 with CVE-2020-29651 mitigated

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -491,8 +491,11 @@ termcolor==1.1.0
 #pytest==3.8.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #py==1.8.0
-py==1.9.0
-
+# @modified 20201212 - Support #3874: SNYK-PYTHON-PY-1049546
+# Dependency vulnerability - py - CVE-2020-29651 #378
+# Update to py 1.10.0
+#py==1.9.0
+py==1.10.0
 # @modified 20190426 - Task #2964: Update dependencies
 #pytest==4.4.0
 # @modified 20190529 - Task #3060: Update dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ scikit-learn==0.23.1
 future==0.18.2
 tsfresh==0.4.0
 termcolor==1.1.0
-py==1.9.0
+py==1.10.0
 pytest==5.4.3
 SQLAlchemy==1.3.19
 pymemcache==3.2.0


### PR DESCRIPTION
IssueID #3694: #3874: SNYK-PYTHON-PY-1049546
Dependency vulnerability - py - CVE-2020-29651 #378

- Update py to 1.10.0 which resolves CVE-2020-29651 by implementing
  https://github.com/pytest-dev/py/pull/257 which fixes
  https://github.com/pytest-dev/py/issues/256

Modified:
dev-requirements.txt
requirements.txt