### PR TITLE
webapp - utilities - match_metric

### DIFF
--- a/skyline/matched_or_regexed_in_list.py
+++ b/skyline/matched_or_regexed_in_list.py
@@ -9,7 +9,10 @@ import re
 # @added 20200423 - Feature #3512: matched_or_regexed_in_list function
 #                   Feature #3508: ionosphere_untrainable_metrics
 #                   Feature #3486: analyzer_batch
-def matched_or_regexed_in_list(current_skyline_app, base_name, match_list):
+# @added 20201212 - Feature #3880: webapp - utilities - match_metric
+# Added debug_log parameter for allowing for debug logging to be turned on in
+# webapp utilities requests
+def matched_or_regexed_in_list(current_skyline_app, base_name, match_list, debug_log=False):
     """
     Determine if a pattern is in a list as a:
     1) absolute match
@@ -30,6 +33,8 @@ def matched_or_regexed_in_list(current_skyline_app, base_name, match_list):
 
     """
     debug_matched_or_regexed_in_list = None
+    if debug_log:
+        debug_matched_or_regexed_in_list = True
 
     if debug_matched_or_regexed_in_list:
         current_skyline_app_logger = str(current_skyline_app) + 'Log'

--- a/skyline/webapp/templates/match_metric.html
+++ b/skyline/webapp/templates/match_metric.html
@@ -1,0 +1,98 @@
+{% block match_metric_block %}
+<!--
+# @added 20201212 - Feature #3880: webapp - utilities - match_metric
+ -->
+<!-- BEGIN /utilities match_metric block -->
+{% if print_debug == 'True' %}
+<code> DEBUG </code> :: /utilities match_metric_block</br>
+{% endif %}
+
+{% if display_message %}
+<code> ERROR </code></br>
+<code> message </code>: {{ display_message }}<br>
+{% endif %}
+
+<div class="navbar-header" role="navigation">
+  <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="icon-bar"></span>
+    <span class="icon-bar"></span>
+  </button>
+		<ul class="nav nav-tabs" role="view_tablist" id="view">
+		  <li class="active"><a href="/utilities"><span class="logo"><span class="sky">Match</span> <span class="re">metric name</span></span></a></li>
+		</ul>
+		<div class="tab-content">
+	  	<div class="tab-pane active" id="view">
+	<br>
+  <div class="navbar-header" role="navigation">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+	<div class="col-md-12">
+
+	  <h4><span class="logo"><span class="sky">Match ::</span> <span class="re">metric name</span></span> (using the internal <code>matched_or_regexed_in_list</code> function)</h4>
+
+  {% if match_metric %}
+    {% if pattern_match %}
+	  <div class="alert alert-success">
+	    <strong>metric</strong> :: {{ metric }}<br>
+	    <strong>settings_list</strong> :: {{ settings_list }}<br>
+	    <strong>match_with</strong> :: {{ match_with }}<br>
+	    <strong>Matched</strong> :: {{ pattern_match }}<br>
+	    <strong>Matched by</strong> :: {{ matched_by }}<br>
+	  </div>
+    {% else %}
+	  <div class="alert alert-danger">
+	    <strong>metric</strong> :: {{ metric }}<br>
+	    <strong>settings_list</strong> :: {{ settings_list }}<br>
+	    <strong>match_with</strong> :: {{ match_with }}<br>
+	    <strong>matched</strong> :: {{ pattern_match }}<br>
+	    <strong>matched_by</strong> :: {{ matched_by }}<br>
+	  </div>
+    {% endif %}
+  {% endif %}
+	  <div class="alert alert-warning">
+	    Using a regex in the <code>Match with</code> input field may not have the expected results as there seems to possibly be an encoding issue.<br>
+	  </div>
+        <form action="match_metric" method=post enctype=multipart/form-data>
+  		  <table class="table table-hover">
+  		    <thead>
+  		      <tr>
+  		        <th>Option</th>
+  		        <th>value</th>
+  		      </tr>
+  		    </thead>
+  		    <tbody>
+  		      <tr>
+  		        <td>Metric</td>
+  		        <td><input type="text" name="metric" value="" /> the metric name or namespace you want to test e.g. webserver-1.nginx.status_code.200</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Match settings list</td>
+  		        <td><input type="text" name="settings_list" value="" /> the settings list item you want to test against e.g SKIP_LIST</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Match with</td>
+  		        <td><input type="text" name="match_with" value="" />
+              You can manually enter a pattern you wish to test e.g. nginx.200 (substring, namespace, metric name or namespace elements only, regex may work but has not been fully tested)
+              </td>
+  		      </tr>
+  		    </tbody>
+  		  </table>
+        <br>
+        <input type="submit" value="Match metric">
+      </form>
+      </div>
+  </div>
+
+	</div>
+	</div>
+	</div>
+
+<!-- END /match_metric block -->
+{% endblock %}

--- a/skyline/webapp/templates/utilities.html
+++ b/skyline/webapp/templates/utilities.html
@@ -1,26 +1,17 @@
-<!DOCTYPE html>
-<html>
-    <body>
-        <title>skyline</title>
-        <script src="/static/js/mousetrap.min.js"></script>
-        <script src="/static/jquery-2.2.4/dist/jquery.min.js"></script>
-        <script src="/static/strftime-0.9.2/strftime-min.js"></script>
-        <script src="/static/dygraph-1.1.1/dygraph-combined.js"></script>
-        <script src="/static/bootstrap-3.3.6-dist/js/bootstrap.min.js"></script>
-        <script src="/static/js/skyline.js"></script>
+{% extends "layout.html" %}
+{% block body %}
+<!-- BEGIN /utilities block -->
+<!--
+# @added 20201212 - Feature #3880: webapp - utilities - match_metric
+ -->
+	<ol class="breadcrumb">
+  	<div class="breadcrumb">
+  		<li><a href="/">Home</a></li>
+  		<li><a href="/utilities">Utilities</a></li>
+  		<li class="active"><span class="logo"><span class="sky">Match</span> <span class="re">metric name</span></li>
+    </div>
+	</ol>
+  {% include "match_metric.html" %}
 
-        <link rel="stylesheet" href="/static/bootstrap-3.3.6-dist/css/bootstrap.min.css">
-        <link rel="stylesheet" type="text/css" href="/static/bootstrap-3.3.6-dist/css/bootstrap-theme.min.css">
-        <link rel="stylesheet" href="/static/fontawesome-4.6.3/css/font-awesome.min.css">
-        <link rel="stylesheet" href="/static/css/skyline.css">
-
-        <div id="navbar">
-            <div class='container'>
-                <a href='/' id="logo" class='brand' href='/'>
-                    skyline
-                </a>
-            </div>
-        </div>
-
-    </body>
-</html>
+<!-- END /flux_frontend block -->
+{% endblock %}


### PR DESCRIPTION
IssueID #3880: webapp - utilities - match_metric

- Added page to utilities to submit and metric name and test against a settings
  list or a provided string.  Possible issue with encoding in the use of a regex
  string.

IssueID #3824: get_cluster_data

- Append all URI key values to the training page redirect
- Added ability to pass a custom redirect URL, even badly if required

Added:
skyline/webapp/templates/match_metric.html
Modified:
skyline/matched_or_regexed_in_list.py
skyline/webapp/templates/utilities.html
skyline/webapp/webapp.py