### PR TITLE
Corrections and improvements to sync_cluster_files

### DIFF
--- a/docs/running-multiple-skylines.rst
+++ b/docs/running-multiple-skylines.rst
@@ -40,7 +40,7 @@ The following settings pertain to running multiple Skyline instances:
 
 - :mod:`settings.REMOTE_SKYLINE_INSTANCES`
 - :mod:`settings.HORIZON_SHARDS`
-- :mod:`settings.SNYC_CLUSTER_FILES`
+- :mod:`settings.SYNC_CLUSTER_FILES`
 
 With the introduction of Luminosity a requirement for Skyline to pull the time
 series data from remote Skyline instances was added to allow for cross
@@ -59,7 +59,7 @@ configuration (Apache or nginx) needs to allow this.
 username, password and hostname for the other instances in the Skyline cluster
 so that if a request is made to the Skyline webapp for a resource it does not
 have, it can return the other URLs to the client.  This is also used in
-:mod:`settings.SNYC_CLUSTER_FILES` so that each instance in the cluster can
+:mod:`settings.SYNC_CLUSTER_FILES` so that each instance in the cluster can
 sync relevant Ionosphere training data andd features profiles data to itself.
 
 It is used by Skyline internally to request resources from other Skyline

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -1407,7 +1407,7 @@ are assigned to the specific server (shard).  This enables all Skyline servers
 that are running Horizon to receiver the entire metric population stream from
 mulitple Graphite carbon-relays and drop (not submit to their Redis instance)
 any metrics that do not belong to their shard.  Related settings are
-:mod:`settings.REMOTE_SKYLINE_INSTANCES` and :mod:`settings.SNYC_CLUSTER_FILES`
+:mod:`settings.REMOTE_SKYLINE_INSTANCES` and :mod:`settings.SYNC_CLUSTER_FILES`
 
 - **Example**::
 
@@ -1439,9 +1439,9 @@ HORIZON_SHARD_DEBUG = False
 :vartype HORIZON_SHARD_DEBUG: boolean
 """
 
-SNYC_CLUSTER_FILES = False
+SYNC_CLUSTER_FILES = False
 """
-:var SNYC_CLUSTER_FILES: ADVANCED FEATURE - If Skyline is running in a clustered
+:var SYNC_CLUSTER_FILES: ADVANCED FEATURE - If Skyline is running in a clustered
     configuration the :mod:`settings.REMOTE_SKYLINE_INSTANCES` can sync
     Ionosphere training data and features_profiles dirs and files between each
     other.  This allows for the relevant Ionosphere data to be distributed to
@@ -1454,7 +1454,7 @@ SNYC_CLUSTER_FILES = False
     :mod:`settings.REMOTE_SKYLINE_INSTANCES`, :mod:`settings.HORIZON_SHARDS`,
     :mod:`settings.IONOSPHERE_DATA_FOLDER` and
     :mod:`settings.IONOSPHERE_PROFILES_FOLDER`
-:vartype SNYC_CLUSTER_FILES: boolean
+:vartype SYNC_CLUSTER_FILES: boolean
 """
 
 SKIP_LIST = [
@@ -2787,7 +2787,7 @@ REMOTE_SKYLINE_INSTANCES = []
     by default the previous 12 minutes, for all the metrics on the other Skyline
     instance/s (gizpped) in order to run correlations in all metrics in the
     population.  Related settings are :mod:`settings.HORIZON_SHARDS` and
-    :mod:`settings.SNYC_CLUSTER_FILES`
+    :mod:`settings.SYNC_CLUSTER_FILES`
 :vartype REMOTE_SKYLINE_INSTANCES: list
 
 **For example**, the IP or FQDN, the username, password and hostname as strings str::


### PR DESCRIPTION
IssueID #3890: metrics_manager - sync_cluster_files
IssueID #3870: metrics_manager - check_data_sparsity

- Handle if roomba has not pruned some data in minutes (3870)
- Remove the entry from the ionosphere.training data Redis set if the directory
  does not exist on this node in webapp (3890)
- Correct SNYC_CLUSTER_FILES to SYNC_CLUSTER_FILES (3890)
- Add some caching and use sefl functions (3890)

Modified:
docs/running-multiple-skylines.rst
skyline/analyzer/metrics_manager.py
skyline/settings.py
skyline/webapp/webapp.py