### PR TITLE
luminosity - Allow for longer cluster responses

### DIFF
--- a/skyline/luminosity/luminosity.py
+++ b/skyline/luminosity/luminosity.py
@@ -816,7 +816,13 @@ class Luminosity(Thread):
             # Self monitor processes and terminate if any spin_process has run
             # for to long
             p_starts = time()
-            while time() - p_starts <= 60:
+            # @modified 20201222 - Feature #3824: get_cluster_data
+            # Allow for longer cluster responses with large metric populations
+            # while time() - p_starts <= 60:
+            allow_to_run_for = 60
+            if settings.REMOTE_SKYLINE_INSTANCES:
+                allow_to_run_for = 90
+            while time() - p_starts <= allow_to_run_for:
                 if any(p.is_alive() for p in pids):
                     # Just to avoid hogging the CPU
                     sleep(.1)

--- a/skyline/luminosity/process_correlations.py
+++ b/skyline/luminosity/process_correlations.py
@@ -487,7 +487,13 @@ def get_remote_assigned(anomaly_timestamp, resolution):
         try:
             # @modified 20190519 - Branch #3002: docker
             # r = requests.get(url, timeout=15, auth=(remote_user, remote_password))
-            r = requests.get(url, timeout=15, auth=(remote_user, remote_password), verify=verify_ssl)
+            # @modified 20201222 - Feature #3824: get_cluster_data
+            # Allow for longer response
+            # r = requests.get(url, timeout=15, auth=(remote_user, remote_password), verify=verify_ssl)
+            # @modified 20201222 - Feature #3824: get_cluster_data
+            # Allow for longer cluster responses with large metric populations
+            # r = requests.get(url, timeout=15, auth=(remote_user, remote_password), verify=verify_ssl)
+            r = requests.get(url, timeout=65, auth=(remote_user, remote_password), verify=verify_ssl)
             if int(r.status_code) == 200:
                 logger.info('get_remote_assigned :: time series data retrieved from %s' % remote_url)
                 response_ok = True


### PR DESCRIPTION
IssueID #3824: get_cluster_data

- Allow for longer cluster responses with large metric populations

Modified:
skyline/luminosity/luminosity.py
skyline/luminosity/process_correlations.py