### PR TITLE
new tsfresh and feature extraction method

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,7 +14,10 @@ wheel
 #redis==3.3.8
 #hiredis==1.0.0
 redis==3.5.3
-hiredis==1.0.1
+
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#hiredis==1.0.1
+hiredis==1.1.0
 
 ## python-daemon and deps
 # @modified 20161224 - Task #1758: Update deps in Ionosphere
@@ -109,7 +112,9 @@ Flask==1.1.2
 #simplejson==3.13.2
 # @modified 20200104 - Branch #3262: py3
 #simplejson==3.16.0
-simplejson==3.17.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#simplejson==3.17.0
+simplejson==3.17.2
 
 # @modified 20180105 - Task #2272: update deps for luminosity branch
 #six==1.10.0
@@ -141,13 +146,17 @@ funcsigs==1.0.2
 #pbr==5.2.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #pbr==5.4.2
-pbr==5.4.5
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#pbr==5.4.5
+pbr==5.5.1
 
 # @modified 20190529 - Task #3060: Update dependencies
 #mock==2.0.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #mock==3.0.5
-mock==4.0.2
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#mock==4.0.2
+mock==4.0.3
 
 # If python-2.6 is being used, distribute is probably still required
 #distribute
@@ -179,7 +188,9 @@ mock==4.0.2
 #numpy==1.16.3
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #numpy==1.16.4
-numpy==1.19.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#numpy==1.19.0
+numpy==1.19.4
 
 ## scipy and deps
 # @modified 20160820 - Issue #23 Test dependency updates
@@ -201,7 +212,9 @@ numpy==1.19.0
 #scipy==1.2.1
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #scipy==1.2.2
-scipy==1.5.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#scipy==1.5.0
+scipy==1.5.4
 
 ## matplotlib and co
 # @modified 20161119 - Branch #922: ionosphere
@@ -240,7 +253,9 @@ python-dateutil==2.8.1
 #pytz==2019.1
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #pytz==2019.2
-pytz==2020.1
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#pytz==2020.1
+pytz==2020.5
 
 cycler==0.10.0
 # @modified 20160820 - Issue #23 Test dependency updates
@@ -275,7 +290,9 @@ pyparsing==2.4.7
 #matplotlib==2.2.3
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #matplotlib==2.2.4
-matplotlib==3.2.2
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#matplotlib==3.2.2
+matplotlib==3.3.3
 
 ## pandas and deps
 # @modified 20161119 - Branch #922: ionosphere
@@ -295,7 +312,9 @@ matplotlib==3.2.2
 #pandas==0.23.4
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #pandas==0.24.2
-pandas==0.25.3
+# @modified 20201231 - Task #3898: Test Python 3.8.6 and deps
+#pandas==0.25.3
+pandas==1.2.0
 
 # @modified 20180416 - Task #2272: update deps for luminosity branch
 #patsy==0.4.1
@@ -326,7 +345,9 @@ patsy==0.5.1
 #statsmodels==0.9.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #statsmodels==0.10.1
-statsmodels==0.11.1
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#statsmodels==0.11.1
+statsmodels==0.12.1
 
 # @modified 20160820 - Issue #23 Test dependency updates
 #msgpack-python==0.4.7
@@ -356,7 +377,9 @@ msgpack-python==0.5.6
 #requests==2.21.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #requests==2.22.0
-requests==2.24.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#requests==2.24.0
+requests==2.25.1
 
 # ALERTERS - uncomment any alerters you want to enable
 python-simple-hipchat==0.4.0
@@ -407,7 +430,9 @@ pygerduty==0.38.3
 #mysql-connector-python==8.0.15
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #mysql-connector-python==8.0.16
-mysql-connector-python==8.0.20
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#mysql-connector-python==8.0.20
+mysql-connector-python==8.0.22
 
 # For a production WSGI HTTP Server for the Webapp
 # @modified 20170809 - Task #2138: Update deps
@@ -432,7 +457,9 @@ gunicorn==20.0.4
 #pipdeptree==0.13.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #pipdeptree==0.13.2
-pipdeptree==1.0.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#pipdeptree==1.0.0
+pipdeptree==2.0.0
 
 # @added 20161119 - Branch #922: ionosphere
 ## tsfresh and deps
@@ -446,7 +473,9 @@ pipdeptree==1.0.0
 #scikit_learn==0.19.2
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #scikit_learn==0.20.3
-scikit-learn==0.23.1
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#scikit-learn==0.23.1
+scikit-learn==0.24.0
 
 # @modified 20190412 - Task #2926: Update dependencies
 #future==0.16.0
@@ -466,7 +495,11 @@ future==0.18.2
 # taking up to almost 600 seconds to calculate on a timeseries of length 10075
 # (168h - 1 datapoint per 60s)
 #tsfresh==0.3.1
-tsfresh==0.4.0
+# @added 20210101 - Task #3926: Test Skyline with dependencies updates - tsfresh v0.17.9
+# Update tsfresh to earthgecko/tsfresh branch v0.17.9
+#tsfresh==0.4.0
+git+git://github.com/earthgecko/tsfresh@05ee36c#egg=tsfresh
+
 termcolor==1.1.0
 
 # @added 20161127 - Branch #922: ionosphere
@@ -496,6 +529,7 @@ termcolor==1.1.0
 # Update to py 1.10.0
 #py==1.9.0
 py==1.10.0
+
 # @modified 20190426 - Task #2964: Update dependencies
 #pytest==4.4.0
 # @modified 20190529 - Task #3060: Update dependencies
@@ -504,7 +538,9 @@ py==1.10.0
 #pytest==4.5.0
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #pytest==4.6.5
-pytest==5.4.3
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#pytest==5.4.3
+pytest==6.2.1
 
 # @added 20161130 - Branch #922: ionosphere
 ## sqlalchemy by this stage of the (no deps)
@@ -528,7 +564,10 @@ pytest==5.4.3
 #SQLAlchemy==1.3.7
 # @modified 20200828 - Task #3720: Update sqlalchemy - SNYK-PYTHON-SQLALCHEMY-590109
 #SQLAlchemy==1.3.18
-SQLAlchemy==1.3.19
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#SQLAlchemy==1.3.19
+SQLAlchemy==1.3.22
+
 # @added 20170809 - Task #2132: Optimise Ionosphere DB usage
 # @modified 20180416 - Task #2272: update deps for luminosity branch
 #pymemcache==1.4.3
@@ -538,7 +577,9 @@ SQLAlchemy==1.3.19
 #pymemcache==2.1.1
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #pymemcache==2.2.2
-pymemcache==3.2.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#pymemcache==3.2.0
+pymemcache==3.4.0
 
 # @added 20180520 - Feature #2378: Add redis auth to Skyline and rebrow
 # pycrypto replaced with pycryptodome
@@ -557,7 +598,10 @@ PyJWT==1.7.1
 # Using fork with fixes as per
 # https://github.com/linkedin/luminol/pull/39 - Passed max_shift_seconds to milliseconds
 # https://github.com/linkedin/luminol/pull/41 - fix normalize
-git+git://github.com/earthgecko/luminol@d429044#egg=luminol
+# @modified 20201231 - Task #3898: Test Python 3.8.6 and deps
+# Update future version in luminol
+#git+git://github.com/earthgecko/luminol@d429044#egg=luminol
+git+git://github.com/earthgecko/luminol@2de3fb2#egg=luminol
 
 # @added 20181006 - Feature #2618: alert_slack
 # @modified 20190412 - Task #2926: Update dependencies
@@ -567,7 +611,9 @@ git+git://github.com/earthgecko/luminol@d429044#egg=luminol
 #slackclient==1.3.1
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #slackclient==1.3.2
-slackclient==2.7.2
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#slackclient==2.7.2
+slackclient==2.9.3
 
 # @added 20190412 - Task #2926: Update dependencies
 # Added to address CVE-2018-20060 as is required by requests at >=1.21.1,<1.25
@@ -581,7 +627,9 @@ slackclient==2.7.2
 #urllib3==1.24.3
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #urllib3==1.25.3
-urllib3==1.25.9
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#urllib3==1.25.9
+urllib3==1.26.2
 
 # @added 201906025 - Branch #956: flux
 graphyte==1.6.0
@@ -590,7 +638,10 @@ falcon==2.0.0
 
 # @added 20200517 - Feature #3550: flux.uploaded_data_worker
 #                   Feature #3538: webapp - upload_data endpoint
-xlrd==1.2.0
+# @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
+#xlrd==1.2.0
+xlrd==2.0.1
+
 # @added 20200520 - Feature #3550: flux.uploaded_data_worker
 # pin to 0.1.6 until pandas-1.0.3 has been thoroughly tested
 #pandas_log==0.1.7; python_version >= '3.2'

--- a/docs/tsfresh.rst
+++ b/docs/tsfresh.rst
@@ -3,12 +3,40 @@ tsfresh
 
 The Ionosphere branch introduced tsfresh to the Skyline stack to enable the
 creation of feature profiles for time series that the user deems to be not
-anomalous.
-
-https://github.com/blue-yonder/tsfresh/
+anomalous. https://github.com/blue-yonder/tsfresh/
 
 See `Development - Ionosphere <development/ionosphere.html>`__ for the long
 trail that lead to tsfresh.
+
+Skyline tsfresh fork
+--------------------
+
+Due to the addition of new algorithms/features and modifications to tsfresh, the
+original blue-yonder/tsfresh package can no longer be run on any of the tsfresh
+releases since v0.5.0 with Skyline to achieve consistent results on features
+extraction.  Therefore Skyline runs a modified fork of the tsfresh.  This
+modified fork maintains the features extracted at v0.4.0 but moves this tsfresh
+forked version forward in line with blue-yonder/tsfresh in terms of tsfresh
+internals and dependencies, etc.
+
+https://github.com/earthgecko/tsfresh
+
+In this fork:
+
+- New features added to blue-yonder/tsfresh are disabled
+- Original methods for features are maintained even if they are changed in
+  blue-yonder/tsfresh
+
+.. note:: these branches/versions are tested against the
+  tests/baseline/tsfresh_features_test.py, which was removed from
+  blue-yonder/tsfresh in v0.7.0 but has been readded to this fork. These
+  branches/versions are only tested via the Skyline build tests, they are not
+  tested against the tsfresh tests. Seeing as this fork follows the
+  blue-yonder/tsfresh versions and retrospectively makes backwards compatible
+  changes to the settings and feature_calculators.py which work with the Skyline
+  tests. Therefore these changes are not currently backported to the tsfresh
+  tests themselves and the tsfresh tests will fail if run against any of theses
+  branches.
 
 tsfresh and Graphite integration
 --------------------------------
@@ -41,13 +69,13 @@ calculate the features for.
 :type string: str
 
 Run the script with, a virtualenv example is shown but you can run just with
-Python-2.7 from wherever you save the script:
+Python-3.8 from wherever you save the script:
 
 .. code-block:: bash
 
     cd "${PYTHON_VIRTUALENV_DIR}/projects/${PROJECT}"
     source bin/activate
-    bin/python2.7 tsfresh_features/scripts/tsfresh_graphite_csv path_to_your_graphite_csv [pytz_timezone]
+    bin/python3.8 tsfresh_features/scripts/tsfresh_graphite_csv path_to_your_graphite_csv [pytz_timezone]
     deactivate
 
 Where path_to_your_graphite_csv.csv is a single metric time series that has been

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ pytest==5.4.3
 SQLAlchemy==1.3.19
 pymemcache==3.2.0
 PyJWT==1.7.1
-git+git://github.com/earthgecko/luminol@d429044#egg=luminol
+git+git://github.com/earthgecko/luminol@2de3fb2#egg=luminol
 slackclient==2.7.2
 urllib3==1.25.9
 graphyte==1.6.0

--- a/skyline/features_profile.py
+++ b/skyline/features_profile.py
@@ -13,7 +13,10 @@ from timeit import default_timer as timer
 import pandas as pd
 
 from tsfresh.feature_extraction import (
-    extract_features, ReasonableFeatureExtractionSettings)
+
+    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+    # extract_features, ReasonableFeatureExtractionSettings)
+    extract_features, EfficientFCParameters)
 from tsfresh import __version__ as tsfresh_version
 
 import settings
@@ -393,12 +396,22 @@ def calculate_features_profile(current_skyline_app, timestamp, metric, context):
         # In terms of inline feature calculatation, always exclude
         # high_comp_cost features.
         # df_features = extract_features(df, column_id='metric', column_sort='timestamp', column_kind=None, column_value=None)
-        tsf_settings = ReasonableFeatureExtractionSettings()
+        # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+        # tsf_settings = ReasonableFeatureExtractionSettings()
+        # >>> from tsfresh.feature_extraction import extract_features, EfficientFCParameters
+        # >>> extract_features(df, default_fc_parameters=EfficientFCParameters())
+
         # Disable tqdm progress bar
-        tsf_settings.disable_progressbar = True
+        # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+        # tsf_settings.disable_progressbar = True
+
         df_features = extract_features(
-            df, column_id='metric', column_sort='timestamp', column_kind=None,
-            column_value=None, feature_extraction_settings=tsf_settings)
+            # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+            # df, column_id='metric', column_sort='timestamp', column_kind=None,
+            # column_value=None, feature_extraction_settings=tsf_settings)
+            df, default_fc_parameters=EfficientFCParameters(),
+            column_id='metric', column_sort='timestamp', column_kind=None,
+            column_value=None, disable_progressbar=True)
         # @modified 20190413 - Bug #2934: Ionosphere - no mirage.redis.24h.json file
         # Added log_context to report the context
         current_logger.info('%s :: features extracted from %s data' % (

--- a/skyline/ionosphere/common_functions.py
+++ b/skyline/ionosphere/common_functions.py
@@ -12,7 +12,9 @@ from pymemcache.client.base import Client as pymemcache_Client
 import numpy as np
 import pandas as pd
 from tsfresh.feature_extraction import (
-    extract_features, ReasonableFeatureExtractionSettings)
+    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+    # extract_features, ReasonableFeatureExtractionSettings)
+    extract_features, EfficientFCParameters)
 
 import settings
 from skyline_functions import get_memcache_metric_object
@@ -392,8 +394,10 @@ def minmax_scale_check(
         settings.SKYLINE_TMP_DIR, metric_timestamp, base_name)
     anomalous_fp_fname_out = anomalous_ts_csv + '.transposed.csv'
 
-    tsf_settings = ReasonableFeatureExtractionSettings()
-    tsf_settings.disable_progressbar = True
+    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+    # tsf_settings = ReasonableFeatureExtractionSettings()
+    # tsf_settings.disable_progressbar = True
+
     minmax_fp_features_sum = None
     minmax_anomalous_features_sum = None
     if minmax_anomalous_ts and minmax_fp_ts:
@@ -439,8 +443,12 @@ def minmax_scale_check(
             logger.error('error :: failed to created data frame from %s' % (str(minmax_fp_ts_csv)))
         try:
             df_features = extract_features(
-                df, column_id='metric', column_sort='timestamp', column_kind=None,
-                column_value=None, feature_extraction_settings=tsf_settings)
+                # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+                # df, column_id='metric', column_sort='timestamp', column_kind=None,
+                # column_value=None, feature_extraction_settings=tsf_settings)
+                df, default_fc_parameters=EfficientFCParameters(),
+                column_id='metric', column_sort='timestamp', column_kind=None,
+                column_value=None, disable_progressbar=True)
         except:
             logger.error(traceback.format_exc())
             logger.error('error :: failed to created df_features from %s' % (str(minmax_fp_ts_csv)))
@@ -490,8 +498,12 @@ def minmax_scale_check(
         df = pd.read_csv(anomalous_ts_csv, delimiter=',', header=None, names=['metric', 'timestamp', 'value'])
         df.columns = ['metric', 'timestamp', 'value']
         df_features_current = extract_features(
-            df, column_id='metric', column_sort='timestamp', column_kind=None,
-            column_value=None, feature_extraction_settings=tsf_settings)
+            # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+            # df, column_id='metric', column_sort='timestamp', column_kind=None,
+            # column_value=None, feature_extraction_settings=tsf_settings)
+            df, default_fc_parameters=EfficientFCParameters(),
+            column_id='metric', column_sort='timestamp', column_kind=None,
+            column_value=None, disable_progressbar=True)
 
         # Create transposed features csv
         if not os.path.isfile(anomalous_fp_fname_out):

--- a/skyline/ionosphere/ionosphere.py
+++ b/skyline/ionosphere/ionosphere.py
@@ -53,7 +53,9 @@ from pymemcache.client.base import Client as pymemcache_Client
 # @added 20180617 - Feature #2404: Ionosphere - fluid approximation
 import pandas as pd
 from tsfresh.feature_extraction import (
-    extract_features, ReasonableFeatureExtractionSettings)
+    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+    # extract_features, ReasonableFeatureExtractionSettings)
+    extract_features, EfficientFCParameters)
 
 import settings
 from skyline_functions import (
@@ -3052,8 +3054,10 @@ class Ionosphere(Thread):
                         settings.SKYLINE_TMP_DIR, metric_timestamp, base_name)
                     anomalous_fp_fname_out = anomalous_ts_csv + '.transposed.csv'
 
-                    tsf_settings = ReasonableFeatureExtractionSettings()
-                    tsf_settings.disable_progressbar = True
+                    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+                    # tsf_settings = ReasonableFeatureExtractionSettings()
+                    # tsf_settings.disable_progressbar = True
+
                     minmax_fp_features_sum = None
                     minmax_anomalous_features_sum = None
                     if minmax_anomalous_ts and minmax_fp_ts:
@@ -3101,8 +3105,12 @@ class Ionosphere(Thread):
                             logger.error('error :: failed to created data frame from %s' % (str(minmax_fp_ts_csv)))
                         try:
                             df_features = extract_features(
-                                df, column_id='metric', column_sort='timestamp', column_kind=None,
-                                column_value=None, feature_extraction_settings=tsf_settings)
+                                # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+                                # df, column_id='metric', column_sort='timestamp', column_kind=None,
+                                # column_value=None, feature_extraction_settings=tsf_settings)
+                                df, default_fc_parameters=EfficientFCParameters(),
+                                column_id='metric', column_sort='timestamp', column_kind=None,
+                                column_value=None, disable_progressbar=True)
                         except:
                             logger.error(traceback.format_exc())
                             logger.error('error :: failed to created df_features from %s' % (str(minmax_fp_ts_csv)))
@@ -3156,8 +3164,12 @@ class Ionosphere(Thread):
                         df = pd.read_csv(anomalous_ts_csv, delimiter=',', header=None, names=['metric', 'timestamp', 'value'])
                         df.columns = ['metric', 'timestamp', 'value']
                         df_features_current = extract_features(
-                            df, column_id='metric', column_sort='timestamp', column_kind=None,
-                            column_value=None, feature_extraction_settings=tsf_settings)
+                            # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+                            # df, column_id='metric', column_sort='timestamp', column_kind=None,
+                            # column_value=None, feature_extraction_settings=tsf_settings)
+                            df, default_fc_parameters=EfficientFCParameters(),
+                            column_id='metric', column_sort='timestamp', column_kind=None,
+                            column_value=None, disable_progressbar=True)
 
                         del df
 

--- a/skyline/tsfresh_feature_names.py
+++ b/skyline/tsfresh_feature_names.py
@@ -1,4 +1,4 @@
-TSFRESH_VERSION = '0.4.0'
+TSFRESH_VERSION = '0.17.9'
 """
 :var TSFRESH_VERSION: The version of tsfresh installed by pip, this is important
     in terms of feature extraction baselines
@@ -6,7 +6,7 @@ TSFRESH_VERSION = '0.4.0'
 """
 
 # TSFRESH_BASELINE_VERSION = '0.1.2'
-TSFRESH_BASELINE_VERSION = '0.4.0'
+TSFRESH_BASELINE_VERSION = '0.17.9'
 """
 :var TSFRESH_BASELINE_VERSION: The version of tsfresh that was used to generate
     feature extraction baselines on.

--- a/tests/baseline/tsfresh-0.10.2.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.10.2.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.11.3.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.11.3.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.13.1.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.13.1.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.14.1.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.14.1.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.15.2.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.15.2.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.16.1.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.16.1.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.17.9.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.17.9.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.6.1.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.6.1.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.7.2.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.7.2.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.8.2.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.8.2.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh-0.9.1.py3.data.json.features.transposed.csv
+++ b/tests/baseline/tsfresh-0.9.1.py3.data.json.features.transposed.csv
@@ -1,0 +1,217 @@
+variable,tsfresh_features_test
+value__mean_abs_change_quantiles__qh_0.4__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.6,13.0
+value__maximum,10123.0
+value__last_location_of_minimum,0.033333333333333326
+value__approximate_entropy__m_2__r_0.1,0.07689162502170799
+value__value_count__value_inf,0.0
+value__percentage_of_reoccurring_datapoints_to_all_datapoints,0.09259259259259259
+value__length,60.0
+value__median,9981.0
+value__symmetry_looking__r_0.8,1.0
+value__minimum,9856.0
+value__symmetry_looking__r_0.9500000000000001,1.0
+value__abs_energy,5983503421.0
+value__mean,9986.083333333334
+value__ratio_value_number_to_time_series_length,0.9
+value__symmetry_looking__r_0.65,1.0
+value__approximate_entropy__m_2__r_0.5,0.8166299197284519
+value__quantile__q_0.8,10033.2
+value__mean_second_derivate_central,0.7068965517241379
+value__symmetry_looking__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.4,6.0
+value__symmetry_looking__r_0.15000000000000002,1.0
+value__binned_entropy__max_bins_10,2.119743626741142
+value__autocorrelation__lag_6,0.5124801685138614
+value__symmetry_looking__r_0.05,1.0
+value__sample_entropy,2.226461397521245
+value__standard_deviation,56.53915801361822
+value__large_standard_deviation__r_0.0,1.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.2,0.0
+value__number_cwt_peaks__n_5,6.0
+value__count_above_mean,29.0
+value__symmetry_looking__r_0.6000000000000001,1.0
+value__symmetry_looking__r_0.8500000000000001,1.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.6,41.125
+value__mean_abs_change_quantiles__qh_0.2__ql_0.4,0.0
+value__time_reversal_asymmetry_statistic__lag_3,1993963105.1111112
+value__absolute_sum_of_changes,2755.0
+value__quantile__q_0.3,9962.7
+value__number_cwt_peaks__n_1,9.0
+value__first_location_of_minimum,0.016666666666666666
+value__symmetry_looking__r_0.25,1.0
+value__symmetry_looking__r_0.55,1.0
+value__symmetry_looking__r_0.9,1.0
+value__symmetry_looking__r_0.35000000000000003,1.0
+value__last_location_of_maximum,0.9666666666666667
+value__symmetry_looking__r_0.0,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.2,12.0
+value__large_number_of_peaks__n_1,1.0
+value__quantile__q_0.6,10004.8
+value__symmetry_looking__r_0.30000000000000004,1.0
+value__has_duplicate_min,0.0
+value__autocorrelation__lag_8,0.3600822542968586
+value__quantile__q_0.2,9937.8
+value__longest_strike_above_mean,10.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.2,31.61904761904762
+value__time_reversal_asymmetry_statistic__lag_2,1215832201.5892856
+value__large_standard_deviation__r_0.35000000000000003,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.4,0.0
+value__symmetry_looking__r_0.4,1.0
+value__number_peaks__n_5,4.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.0,35.6
+value__mean_abs_change_quantiles__qh_1.0__ql_0.4,45.074074074074076
+value__variance_larger_than_standard_deviation,1.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.6,0.0
+value__large_standard_deviation__r_0.30000000000000004,0.0
+value__quantile__q_0.1,9909.9
+value__percentage_of_reoccurring_values_to_all_values,0.18333333333333332
+value__range_count__max_1__min_-1,0.0
+value__value_count__value_nan,0.0
+value__has_duplicate,1.0
+value__autocorrelation__lag_5,0.46463952576506445
+value__autocorrelation__lag_1,0.5154799442499526
+value__mean_abs_change_quantiles__qh_0.6__ql_0.2,23.181818181818183
+value__mean_abs_change_quantiles__qh_1.0__ql_0.2,42.46341463414634
+value__mean_abs_change_quantiles__qh_0.2__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.2__ql_0.8,0.0
+value__longest_strike_below_mean,9.0
+value__mean_abs_change,46.69491525423729
+value__large_number_of_peaks__n_3,1.0
+value__sum_values,599165.0
+value__quantile__q_0.4,9975.6
+value__large_standard_deviation__r_0.2,1.0
+value__autocorrelation__lag_4,0.535012070945404
+value__large_standard_deviation__r_0.1,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.4,20.0
+value__approximate_entropy__m_2__r_0.9,0.6797278530812287
+value__quantile__q_0.7,10017.6
+value__large_standard_deviation__r_0.05,1.0
+value__symmetry_looking__r_0.2,1.0
+value__autocorrelation__lag_0,1.0
+value__number_peaks__n_3,9.0
+value__has_duplicate_max,0.0
+value__value_count__value_0,0.0
+value__symmetry_looking__r_0.75,1.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.8,0.0
+value__mean_abs_change_quantiles__qh_0.4__ql_0.6,0.0
+value__mean_abs_change_quantiles__qh_0.6__ql_0.8,0.0
+value__large_standard_deviation__r_0.15000000000000002,1.0
+value__autocorrelation__lag_7,0.6538534951469428
+value__first_location_of_maximum,0.95
+value__large_standard_deviation__r_0.4,0.0
+value__value_count__value_1,0.0
+value__symmetry_looking__r_0.5,1.0
+value__symmetry_looking__r_0.7000000000000001,1.0
+value__symmetry_looking__r_0.45,1.0
+value__value_count__value_-inf,0.0
+value__mean_abs_change_quantiles__qh_0.8__ql_0.0,43.02564102564103
+value__autocorrelation__lag_2,0.36765813197781516
+value__count_below_mean,31.0
+value__kurtosis,-0.028901521751474757
+value__number_peaks__n_1,21.0
+value__time_reversal_asymmetry_statistic__lag_1,836027272.2758621
+value__large_standard_deviation__r_0.25,0.0
+value__autocorrelation__lag_9,0.21748400096837414
+value__mean_abs_change_quantiles__qh_0.6__ql_0.0,42.25
+value__autocorrelation__lag_3,0.41157540616944277
+value__augmented_dickey_fuller,-0.8041220342033477
+value__mean_change,2.389830508474576
+value__approximate_entropy__m_2__r_0.7,0.7705662353813092
+value__approximate_entropy__m_2__r_0.3,0.5560594285625684
+value__skewness,-0.13542292125432515
+value__quantile__q_0.9,10048.9
+value__mean_autocorrelation,1.1720475293977404
+value__mean_abs_change_quantiles__qh_0.2__ql_0.0,29.4
+value__large_standard_deviation__r_0.45,0.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.8,58.333333333333336
+value__sum_of_reoccurring_values,109822.0
+value__mean_abs_change_quantiles__qh_1.0__ql_0.0,46.69491525423729
+value__variance,3196.676388888889
+value__large_number_of_peaks__n_5,0.0
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_2",-40.26584696076512
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_2",5485.741180131762
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_2",7535.02284445965
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_2",6017.192007927546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_2",3308.4304014332133
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_2",1295.7433671924832
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_2",336.63243154202974
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_2",39.91676725858371
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_2",17.95548569182395
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_2",50.25903008787768
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_2",35.90470247450137
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_2",-24.14602386100941
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_2",-61.88712524130824
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_2",-33.66850432521918
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_2",24.2088382102474
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_5",-20.25759713427192
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_5",3771.32544151532
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_5",7120.960920890312
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_5",9670.131692340241
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_5",11207.929406479912
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_5",11696.157551031654
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_5",11253.943680982822
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_5",10110.899443515671
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_5",8545.473828217693
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_5",6826.238621617837
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_5",5169.353887616802
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_5",3717.9693031013257
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_5",2542.019687569354
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_5",1652.1018555118546
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_5",1019.5707851504081
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_10",836.6419785398173
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_10",3543.079676303278
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_10",6167.81421141303
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_10",8634.724847532969
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_10",10876.52373637707
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_10",12835.39894023715
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_10",14466.109489818979
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_10",15737.722443656134
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_10",16639.548449136702
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_10",17169.07664099483
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_10",17339.769765701127
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_10",17183.302683017107
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_10",16737.753845933414
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_10",16046.185770382554
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_10",15154.905872253847
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_0__w_20",18718.957258866507
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_1__w_20",20645.635031408423
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_2__w_20",22554.42070815293
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_3__w_20",24433.795924964932
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_4__w_20",26275.187181689304
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_5__w_20",28065.040620993466
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_6__w_20",29788.065740263246
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_7__w_20",31428.519814904783
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_8__w_20",32985.8151195006
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_9__w_20",34437.54084086011
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_10__w_20",35770.923231998284
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_11__w_20",36992.81478848827
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_12__w_20",38098.19391272645
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_13__w_20",39076.98980573952
+"value__cwt_coefficients__widths_(2, 5, 10, 20)__coeff_14__w_20",39919.05725014526
+value__spkt_welch_density__coeff_2,1843.8211718074986
+value__spkt_welch_density__coeff_5,2859.9769051963667
+value__spkt_welch_density__coeff_8,2536.9954700088906
+value__index_mass_quantile__q_0.1,0.11666666666666667
+value__index_mass_quantile__q_0.2,0.21666666666666667
+value__index_mass_quantile__q_0.3,0.31666666666666665
+value__index_mass_quantile__q_0.4,0.4166666666666667
+value__index_mass_quantile__q_0.6,0.6166666666666667
+value__index_mass_quantile__q_0.7,0.7166666666666667
+value__index_mass_quantile__q_0.8,0.8166666666666667
+value__index_mass_quantile__q_0.9,0.9166666666666666
+value__ar_coefficient__k_10__coeff_0,904.4391850794491
+value__ar_coefficient__k_10__coeff_1,0.1635789481157781
+value__ar_coefficient__k_10__coeff_2,-0.0432470001474492
+value__ar_coefficient__k_10__coeff_3,-0.06654237068301239
+value__ar_coefficient__k_10__coeff_4,0.2836853193919273
+value__fft_coefficient__coeff_0,178744.0
+value__fft_coefficient__coeff_1,-0.8045103874789561
+value__fft_coefficient__coeff_2,-53.13286168327602
+value__fft_coefficient__coeff_3,-338.0
+value__fft_coefficient__coeff_4,122.44503935479203
+value__fft_coefficient__coeff_5,-58.930796134230846
+value__fft_coefficient__coeff_6,13.0
+value__fft_coefficient__coeff_7,112.23530652170984
+value__fft_coefficient__coeff_8,118.18782232848395
+value__fft_coefficient__coeff_9,-248.0

--- a/tests/baseline/tsfresh_features_test.py
+++ b/tests/baseline/tsfresh_features_test.py
@@ -45,6 +45,9 @@ if 'post' in TSFRESH_BASELINE_VERSION:
     travis_tsfresh_version = re.sub('\.post.*', '', TSFRESH_BASELINE_VERSION)
     TSFRESH_BASELINE_VERSION = travis_tsfresh_version
 
+# Directly declared every version hardcoded
+TSFRESH_BASELINE_VERSION = '0.17.9'
+
 python_version = int(sys.version_info[0])
 baseline_dir = os.path.dirname(os.path.realpath(__file__))
 tests_dir = os.path.dirname(baseline_dir)
@@ -229,6 +232,12 @@ class TestTsfreshBaseline(unittest.TestCase):
                     # done
                     if feature_name.replace('"', '') in exclude_py38_features:
                         continue
+
+                    if feature_name in ['nan', 'variable']:
+                        continue
+                    if feature_name == '':
+                        continue
+
                     count_id += 1
                     feature_names.append([count_id, feature_name])
 

--- a/utils/test_ionosphere_echo.py
+++ b/utils/test_ionosphere_echo.py
@@ -12,7 +12,9 @@ import csv
 import numpy as np
 import pandas as pd
 from tsfresh.feature_extraction import (
-    extract_features, ReasonableFeatureExtractionSettings)
+    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+    # extract_features, ReasonableFeatureExtractionSettings)
+    extract_features, EfficientFCParameters)
 from tsfresh import __version__ as tsfresh_version
 
 __location__ = os.path.realpath(os.path.join(os.getcwd(), dirname(__file__)))
@@ -143,12 +145,19 @@ def create_test_features_profile(json_file):
     df = pd.read_csv(ts_csv, delimiter=',', header=None, names=['metric', 'timestamp', 'value'])
 #    print('DataFrame created with %s' % ts_csv)
     df.columns = ['metric', 'timestamp', 'value']
-    tsf_settings = ReasonableFeatureExtractionSettings()
+
+    # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+    # tsf_settings = ReasonableFeatureExtractionSettings()
     # Disable tqdm progress bar
-    tsf_settings.disable_progressbar = True
+    # tsf_settings.disable_progressbar = True
+
     df_features = extract_features(
-        df, column_id='metric', column_sort='timestamp', column_kind=None,
-        column_value=None, feature_extraction_settings=tsf_settings)
+        # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+        # df, column_id='metric', column_sort='timestamp', column_kind=None,
+        # column_value=None, feature_extraction_settings=tsf_settings)
+        df, default_fc_parameters=EfficientFCParameters(),
+        column_id='metric', column_sort='timestamp', column_kind=None,
+        column_value=None, disable_progressbar=True)
     del df
 #    print('features extracted from %s data' % ts_csv)
     # write to disk
@@ -384,8 +393,12 @@ def calculate_features_other_minmax(use_file, i_json_file, metric):
             print('error :: failed to created data frame from %s' % (str(minmax_fp_ts_csv)))
         try:
             df_features = extract_features(
-                df, column_id='metric', column_sort='timestamp', column_kind=None,
-                column_value=None, feature_extraction_settings=tsf_settings)
+                # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+                # df, column_id='metric', column_sort='timestamp', column_kind=None,
+                # column_value=None, feature_extraction_settings=tsf_settings)
+                df, default_fc_parameters=EfficientFCParameters(),
+                column_id='metric', column_sort='timestamp', column_kind=None,
+                column_value=None, disable_progressbar=True)
         except:
             print('error :: failed to created df_features from %s' % (str(minmax_fp_ts_csv)))
         # Create transposed features csv
@@ -432,8 +445,12 @@ def calculate_features_other_minmax(use_file, i_json_file, metric):
         df = pd.read_csv(anomalous_ts_csv, delimiter=',', header=None, names=['metric', 'timestamp', 'value'])
         df.columns = ['metric', 'timestamp', 'value']
         df_features_current = extract_features(
-            df, column_id='metric', column_sort='timestamp', column_kind=None,
-            column_value=None, feature_extraction_settings=tsf_settings)
+            # @modified 20210101 - Task #3928: Update Skyline to use new tsfresh feature extraction method
+            # df, column_id='metric', column_sort='timestamp', column_kind=None,
+            # column_value=None, feature_extraction_settings=tsf_settings)
+            df, default_fc_parameters=EfficientFCParameters(),
+            column_id='metric', column_sort='timestamp', column_kind=None,
+            column_value=None, disable_progressbar=True)
         del df
 
         # Create transposed features csv


### PR DESCRIPTION
IssueID #3928: Update Skyline to use new tsfresh feature extraction method
IssueID #3898: Test Python 3.8.6 and deps

- Update all ionosphere functions to use the new tsfresh feature extraction method
- Update requirements to use earthgecko/tsfresh
- Added tsfresh baseline test data sets
- Update deps
- Update docs

Added:
tests/baseline/tsfresh-0.10.2.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.11.3.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.13.1.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.14.1.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.15.2.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.16.1.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.17.9.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.6.1.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.7.2.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.8.2.py3.data.json.features.transposed.csv
tests/baseline/tsfresh-0.9.1.py3.data.json.features.transposed.csv
tests/baseline/tsfresh_features_test.py
Modified:
dev-requirements.txt
docs/tsfresh.rst
requirements.txt
skyline/features_profile.py
skyline/ionosphere/common_functions.py
skyline/ionosphere/ionosphere.py
skyline/tsfresh_feature_names.py
utils/test_ionosphere_echo.py