### PR TITLE
ionosphere_performance

### DIFF
--- a/docs/analyzer.rst
+++ b/docs/analyzer.rst
@@ -225,18 +225,18 @@ monotonically, metrics that have an incrementing increasing count, so that these
 time series can be handled via their derivative products where appropriate.  For
 full details see `Monotonic metrics <monotonic-metrics.html>`__
 
-Anomaly `end_timestamp`
-======================
+Anomaly end_timestamp
+=====================
 
 The `end_timestamp` means that the anomaly has either:
 
-# Ended, when it is a peak or trough anomaly, and the time series data returns
-  to a state that is represented in the norm in the previous 24 hour period
-# When the state change, in cases of frequency or level shifts, and occurs for
-  sufficient time to begin to be represented in the norm in the previous 24 hour
-  period (:mod:`settings.FULL_DURATION`).  In these cases you might consider the
-  metric to still be in an anomalous state, but in terms of the
-  :mod:`settings.FULL_DURATION` data, it is no longer anomalous.
+1. Ended, when it is a peak or trough anomaly, and the time series data returns
+   to a state that is represented in the norm in the previous 24 hour period
+2. When the state change, in cases of frequency or level shifts, and occurs for
+   sufficient time to begin to be represented in the norm in the previous 24 hour
+   period (:mod:`settings.FULL_DURATION`).  In these cases you might consider the
+   metric to still be in an anomalous state, but in terms of the
+   :mod:`settings.FULL_DURATION` data, it is no longer anomalous.
 
 Push to Mirage
 ==============

--- a/docs/panorama.rst
+++ b/docs/panorama.rst
@@ -55,9 +55,9 @@ a simpler structure and faster for data which is often queried and FULL TEXT
 searching.
 
 The InnoDB storage engine is used for the anomaly table - mostly writes.
-z_fp_ tables are InnoDB tables and each metric that has an Ionosphere features
-profile created (e.g. has been trained) has a z_fp_<metric_id> and a
-z_ts_<metric_id> table created, therefore if you have 10000 metrics and you
+``z_fp_`` tables are InnoDB tables and each metric that has an Ionosphere features
+profile created (e.g. has been trained) has a ``z_fp_<metric_id>`` and a
+``z_ts_<metric_id>`` table created, therefore if you have 10000 metrics and you
 created features profiles (trained) for each one, there would be 20000 tables.
 Bear in mind, that not all metrics will have features profiles created as you
 have to manually train to create each one.

--- a/docs/running-multiple-skylines.rst
+++ b/docs/running-multiple-skylines.rst
@@ -65,12 +65,12 @@ sync relevant Ionosphere training data andd features profiles data to itself.
 It is used by Skyline internally to request resources from other Skyline
 instances to:
 
-1. Retrieve time series data and general data for metrics served by the other
+# Retrieve time series data and general data for metrics served by the other
   Skyline instance/s.
-2. To retrieve resources for certain client and API requests to respond with
+# To retrieve resources for certain client and API requests to respond with
   all the data for the cluster, in terms of unique_metrics, alerting_metrics,
   etc.
-3. To sync Ionosphere data between the cluster instances.
+# To sync Ionosphere data between the cluster instances.
 
 Read about :mod:`settings.HORIZON_SHARDS` see
 `HORIZON_SHARDS <horizon.html#HORIZON_SHARDS>`__ section on the Horizon page.

--- a/skyline/webapp/ionosphere_backend.py
+++ b/skyline/webapp/ionosphere_backend.py
@@ -6413,3 +6413,774 @@ def expected_features_profiles_dirs():
     logger.info('added %s new items to features_profiles_dirs, returning %s items' % (
         str(added_fps), str(len(features_profile_dirs_dict))))
     return features_profile_dirs_dict
+
+
+# @added 20210107 - Feature #3934: ionosphere_performance
+def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timestamp, format):
+    """
+    Analyse the performance of Ionosphere on a metric or metric namespace and
+    create the graph resources or json data as required.
+
+    :rtype:  dict
+
+    """
+    import datetime
+    import pandas as pd
+
+    ionosphere_performance_debug = False
+    determine_start_timestamp = False
+
+    if from_timestamp == 0:
+        start_timestamp = 0
+        determine_start_timestamp = True
+    if from_timestamp != 0:
+        if ":" in from_timestamp:
+            new_from_timestamp = time.mktime(datetime.datetime.strptime(from_timestamp, '%Y%m%d %H:%M').timetuple())
+            start_timestamp = int(new_from_timestamp)
+        if from_timestamp == 'all':
+            start_timestamp = 0
+            determine_start_timestamp = True
+    if until_timestamp and until_timestamp != 'all':
+        if ":" in until_timestamp:
+            new_until_timestamp = time.mktime(datetime.datetime.strptime(until_timestamp, '%Y%m%d %H:%M').timetuple())
+            end_timestamp = int(new_until_timestamp)
+    if until_timestamp == 'all':
+        end_timestamp = int(time.time())
+    if until_timestamp == 0:
+        end_timestamp = int(time.time())
+
+    start_timestamp_str = str(start_timestamp)
+    end_timestamp_str = str(end_timestamp)
+
+    begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+    end_date = datetime.datetime.utcfromtimestamp(end_timestamp).strftime('%Y-%m-%d')
+
+    try:
+        engine, fail_msg, trace = get_an_engine()
+        logger.info(fail_msg)
+    except:
+        trace = traceback.format_exc()
+        logger.error(trace)
+        logger.error('%s' % fail_msg)
+        logger.error('error :: get_ionosphere_performance - could not get a MySQL engine')
+        raise  # to webapp to return in the UI
+    if not engine:
+        trace = 'none'
+        fail_msg = 'error :: get_ionosphere_performance - engine not obtained'
+        logger.error(fail_msg)
+        raise
+    try:
+        metrics_table, log_msg, trace = metrics_table_meta(skyline_app, engine)
+    except:
+        logger.error(traceback.format_exc())
+        logger.error('error :: get_ionosphere_performance - failed to get metrics_table meta')
+        if engine:
+            engine_disposal(engine)
+        raise  # to webapp to return in the UI
+
+    # Determine period
+    frequency = 'D'
+    if 'period' in request.args:
+        period = request.args.get('period', 'daily')
+        if period == 'daily':
+            frequency = 'D'
+        if period == 'weekly':
+            frequency = 'W'
+        if period == 'monthly':
+            frequency = 'M'
+
+    metric_id = None
+    metric_ids = []
+    if metric_like != 'all':
+        metric_like_str = str(metric_like)
+        logger.info('get_ionosphere_performance - metric_like - %s' % metric_like_str)
+        metrics_like_query = text("""SELECT id FROM metrics WHERE metric LIKE :like_string""")
+        metric_like_wildcard = metric_like_str.replace('.%', '')
+        request_key = '%s.%s.%s.%s.%s' % (metric_like_wildcard, begin_date, end_date, frequency, format)
+        plot_title = '%s - %s' % (metric_like_wildcard, period)
+        try:
+            connection = engine.connect()
+            result = connection.execute(metrics_like_query, like_string=metric_like_str)
+            connection.close()
+            for row in result:
+                m_id = row['id']
+                metric_ids.append(int(m_id))
+        except:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            logger.error('error :: get_ionosphere_performance - could not determine ids from metrics table LIKE query')
+            if engine:
+                engine_disposal(engine)
+            return {}
+        # If the from_timestamp is 0 or all
+        if determine_start_timestamp:
+            try:
+                connection = engine.connect()
+                stmt = select([metrics_table.c.created_timestamp], metrics_table.c.id.in_(metric_ids)).limit(1)
+                result = connection.execute(stmt)
+                for row in result:
+                    start_timestamp_date = row['created_timestamp']
+                    break
+                connection.close()
+                start_timestamp_str = str(start_timestamp_date)
+                logger.info('get_ionosphere_performance - determined start_timestamp_str - %s' % start_timestamp_str)
+                new_from_timestamp = time.mktime(datetime.datetime.strptime(start_timestamp_str, '%Y-%m-%d %H:%M:%S').timetuple())
+                start_timestamp = int(new_from_timestamp)
+                logger.info('get_ionosphere_performance - determined start_timestamp - %s' % str(start_timestamp))
+                begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+                logger.info('get_ionosphere_performance - determined begin_date - %s' % str(begin_date))
+                determine_start_timestamp = False
+                request_key = '%s.%s.%s.%s.%s' % (metric_like_wildcard, begin_date, end_date, frequency, format)
+            except:
+                trace = traceback.format_exc()
+                logger.error(trace)
+                logger.error('error :: get_ionosphere_performance - could not determine ids from metrics table LIKE query')
+                if engine:
+                    engine_disposal(engine)
+                return {}
+
+    logger.info('get_ionosphere_performance - metric_ids length - %s' % str(len(metric_ids)))
+
+    if not metric_ids:
+        # stmt = select([metrics_table]).where(metrics_table.c.id > 0)
+        if metric == 'all':
+            request_key = 'all.%s.%s.%s.%s' % (begin_date, end_date, frequency, format)
+            plot_title = 'All metrics - %s' % period
+            # If the from_timestamp is 0 or all
+            if determine_start_timestamp:
+                try:
+                    connection = engine.connect()
+                    stmt = select([metrics_table.c.created_timestamp]).limit(1)
+                    result = connection.execute(stmt)
+                    for row in result:
+                        start_timestamp_date = row['created_timestamp']
+                        break
+                    connection.close()
+                    start_timestamp_str = str(start_timestamp_date)
+                    logger.info('get_ionosphere_performance - determined start_timestamp_str - %s' % start_timestamp_str)
+                    new_from_timestamp = time.mktime(datetime.datetime.strptime(start_timestamp_str, '%Y-%m-%d %H:%M:%S').timetuple())
+                    start_timestamp = int(new_from_timestamp)
+                    logger.info('get_ionosphere_performance - determined start_timestamp - %s' % str(start_timestamp))
+                    begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+                    logger.info('get_ionosphere_performance - determined begin_date - %s' % str(begin_date))
+                    determine_start_timestamp = False
+                    request_key = 'all.%s.%s.%s.%s' % (begin_date, end_date, frequency, format)
+                except:
+                    trace = traceback.format_exc()
+                    logger.error(trace)
+                    logger.error('error :: get_ionosphere_performance - could not determine ids from metrics table LIKE query')
+                    if engine:
+                        engine_disposal(engine)
+                    return {}
+
+        if metric != 'all':
+            logger.info('get_ionosphere_performance - metric - %s' % metric)
+            try:
+                request_key = '%s.%s.%s.%s.%s' % (metric, begin_date, end_date, frequency, format)
+                plot_title = '%s - %s' % (metric, period)
+                connection = engine.connect()
+                stmt = select([metrics_table]).where(metrics_table.c.metric == str(metric))
+                result = connection.execute(stmt)
+                for row in result:
+                    metric_id_str = row['id']
+                    metric_id = int(metric_id_str)
+                    # metric_ids.append(metric_id)
+                connection.close()
+            except:
+                logger.error(traceback.format_exc())
+                logger.error('error :: get_ionosphere_performance - could not determine metric id from metrics')
+                if engine:
+                    engine_disposal(engine)
+                raise
+            if determine_start_timestamp and metric_id:
+                try:
+                    connection = engine.connect()
+                    stmt = select([metrics_table.c.created_timestamp]).where(metrics_table.c.metric == str(metric))
+                    result = connection.execute(stmt)
+                    for row in result:
+                        start_timestamp_date = row['created_timestamp']
+                        break
+                    connection.close()
+                    start_timestamp_str = str(start_timestamp_date)
+                    logger.info('get_ionosphere_performance - determined start_timestamp_str - %s' % start_timestamp_str)
+                    new_from_timestamp = time.mktime(datetime.datetime.strptime(start_timestamp_str, '%Y-%m-%d %H:%M:%S').timetuple())
+                    start_timestamp = int(new_from_timestamp)
+                    logger.info('get_ionosphere_performance - determined start_timestamp - %s' % str(start_timestamp))
+                    begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+                    logger.info('get_ionosphere_performance - determined begin_date - %s' % str(begin_date))
+                    request_key = '%s.%s.%s.%s.%s' % (metric, begin_date, end_date, frequency, format)
+                except:
+                    trace = traceback.format_exc()
+                    logger.error(trace)
+                    logger.error('error :: get_ionosphere_performance - could not determine ids from metrics table LIKE query')
+                    if engine:
+                        engine_disposal(engine)
+                    return {}
+
+            logger.info('get_ionosphere_performance - metric - %s' % str(metric))
+    logger.info('get_ionosphere_performance - metric_id - %s' % str(metric_id))
+
+    if metric != 'all':
+        if not metric_ids and not metric_id:
+            if engine:
+                engine_disposal(engine)
+            performance = {
+                'performance': {'date': None, 'reason': 'no metric data found'},
+                'request_key': request_key,
+                'success': False,
+                'reason': 'no data for metric/s',
+                'plot': None,
+                'csv': None,
+            }
+            return performance
+
+    # Create request_key performance directory
+    ionosphere_dir = path.dirname(settings.IONOSPHERE_DATA_FOLDER)
+    performance_dir = '%s/performance/%s' % (ionosphere_dir, request_key)
+    if not path.exists(performance_dir):
+        mkdir_p(performance_dir)
+
+    # Report anomalies
+    report_anomalies = False
+    if 'anomalies' in request.args:
+        anomalies_str = request.args.get('performance', 'false')
+        if anomalies_str == 'true':
+            report_anomalies = True
+    anomalies = []
+    anomalies_ts = []
+    if report_anomalies:
+        try:
+            anomalies_table, log_msg, trace = anomalies_table_meta(skyline_app, engine)
+            logger.info(log_msg)
+            logger.info('anomalies_table OK')
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: failed to get anomalies_table meta')
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+        try:
+            connection = engine.connect()
+            if metric_ids:
+                stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp], anomalies_table.c.metric_id.in_(metric_ids)).\
+                    where(anomalies_table.c.anomaly_timestamp >= start_timestamp).\
+                    where(anomalies_table.c.anomaly_timestamp <= end_timestamp)
+                result = connection.execute(stmt)
+            elif metric_id:
+                stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp]).\
+                    where(anomalies_table.c.metric_id == int(metric_id)).\
+                    where(anomalies_table.c.anomaly_timestamp >= start_timestamp).\
+                    where(anomalies_table.c.anomaly_timestamp <= end_timestamp)
+                result = connection.execute(stmt)
+            else:
+                stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp]).\
+                    where(anomalies_table.c.anomaly_timestamp >= start_timestamp).\
+                    where(anomalies_table.c.anomaly_timestamp <= end_timestamp)
+                result = connection.execute(stmt)
+            for row in result:
+                anomaly_id = row['id']
+                anomaly_timestamp = row['anomaly_timestamp']
+                anomalies.append(int(anomaly_timestamp))
+                # anomalies_ts.append([datetime.datetime.fromtimestamp(int(anomaly_timestamp)), int(anomaly_id)])
+                anomalies_ts.append([int(anomaly_timestamp), int(anomaly_id)])
+            connection.close()
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: could not determine anomaly ids')
+            if engine:
+                engine_disposal(engine)
+            raise
+        logger.info('get_ionosphere_performance - anomalies_ts length - %s' % str(len(anomalies_ts)))
+
+    fp_type = 'all'
+    if 'fp_type' in request.args:
+        fp_type = request.args.get('fp_type', 'all')
+
+    # Get fp_ids
+    fp_ids = []
+    fp_ids_ts = []
+    try:
+        ionosphere_table, log_msg, trace = ionosphere_table_meta(skyline_app, engine)
+        logger.info(log_msg)
+    except:
+        logger.error(traceback.format_exc())
+        logger.error('error :: get_ionosphere_performance - failed to get ionosphere_table meta')
+        if engine:
+            engine_disposal(engine)
+        raise  # to webapp to return in the UI
+    try:
+        connection = engine.connect()
+        if metric_ids:
+            if fp_type == 'user':
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                    where(ionosphere_table.c.generation <= 1)
+            elif fp_type == 'learnt':
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                    where(ionosphere_table.c.generation >= 2)
+            else:
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
+            logger.info('get_ionosphere_performance - determining fp ids of type %s for metric_ids' % fp_type)
+            result = connection.execute(stmt)
+        elif metric_id:
+            if fp_type == 'user':
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
+                    where(ionosphere_table.c.metric_id == int(metric_id)).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                    where(ionosphere_table.c.generation <= 1)
+            elif fp_type == 'learnt':
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
+                    where(ionosphere_table.c.metric_id == int(metric_id)).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                    where(ionosphere_table.c.generation >= 2)
+            else:
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
+                    where(ionosphere_table.c.metric_id == int(metric_id)).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
+            logger.info('get_ionosphere_performance - determining fp ids for metric_id')
+            result = connection.execute(stmt)
+        else:
+            if fp_type == 'user':
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                    where(ionosphere_table.c.generation <= 1)
+            elif fp_type == 'learnt':
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                    where(ionosphere_table.c.generation >= 2)
+            else:
+                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
+                    where(ionosphere_table.c.enabled == 1).\
+                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
+            logger.info('get_ionosphere_performance - determining fp ids for all metrics')
+            result = connection.execute(stmt)
+        for row in result:
+            fp_id = row['id']
+            anomaly_timestamp = row['anomaly_timestamp']
+            fp_ids.append(int(fp_id))
+            fp_ids_ts.append([int(anomaly_timestamp), int(fp_id)])
+        connection.close()
+    except:
+        logger.error(traceback.format_exc())
+        logger.error('error :: get_ionosphere_performance - could not determine fp_ids')
+        if engine:
+            engine_disposal(engine)
+        raise
+    logger.info('get_ionosphere_performance - fp_ids_ts length - %s' % str(len(fp_ids_ts)))
+
+    # Get fp matches
+    try:
+        ionosphere_matched_table, log_msg, trace = ionosphere_matched_table_meta(skyline_app, engine)
+    except:
+        logger.error(traceback.format_exc())
+        logger.error('error :: get_ionosphere_performance - failed to get ionosphere_matched_table_meta_table meta')
+        if engine:
+            engine_disposal(engine)
+        raise  # to webapp to return in the UI
+    fps_matched_ts = []
+    if fp_ids:
+        try:
+            connection = engine.connect()
+            stmt = select([ionosphere_matched_table.c.id, ionosphere_matched_table.c.metric_timestamp], ionosphere_matched_table.c.fp_id.in_(fp_ids)).\
+                where(ionosphere_matched_table.c.metric_timestamp >= start_timestamp).\
+                where(ionosphere_matched_table.c.metric_timestamp <= end_timestamp)
+            result = connection.execute(stmt)
+            for row in result:
+                matched_id = row['id']
+                metric_timestamp = row['metric_timestamp']
+                fps_matched_ts.append([int(metric_timestamp), int(matched_id)])
+            connection.close()
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: get_ionosphere_performance - could not determine timestamps from ionosphere_matched')
+            if engine:
+                engine_disposal(engine)
+            raise
+    logger.info('get_ionosphere_performance - fps_matched_ts - %s' % str(len(fps_matched_ts)))
+
+    # Get layers matches
+    try:
+        ionosphere_layers_matched_table, log_msg, trace = ionosphere_layers_matched_table_meta(skyline_app, engine)
+    except:
+        trace = traceback.format_exc()
+        logger.error(trace)
+        fail_msg = 'error :: get_ionosphere_performance - failed to get ionosphere_layers_matched_table meta'
+        logger.error('%s' % fail_msg)
+        if engine:
+            engine_disposal(engine)
+        raise  # to webapp to return in the UI
+    layers_matched_ts = []
+    if fp_ids:
+        try:
+            connection = engine.connect()
+            stmt = select([ionosphere_layers_matched_table.c.id, ionosphere_layers_matched_table.c.anomaly_timestamp], ionosphere_layers_matched_table.c.fp_id.in_(fp_ids)).\
+                where(ionosphere_layers_matched_table.c.anomaly_timestamp >= start_timestamp).\
+                where(ionosphere_layers_matched_table.c.anomaly_timestamp <= end_timestamp)
+            result = connection.execute(stmt)
+            for row in result:
+                matched_layers_id = row['id']
+                matched_timestamp = row['anomaly_timestamp']
+                layers_matched_ts.append([int(matched_timestamp), int(matched_layers_id)])
+            connection.close()
+        except:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            fail_msg = 'error :: get_ionosphere_performance - could not determine timestamps from ionosphere_layers_matched'
+            logger.error('%s' % fail_msg)
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+    logger.info('get_ionosphere_performance - layers_matched_ts - %s' % str(len(layers_matched_ts)))
+
+    anomalies_df = []
+    if anomalies_ts:
+        try:
+            anomalies_df = pd.DataFrame(anomalies_ts, columns=['date', 'id'])
+            anomalies_df['date'] = pd.to_datetime(anomalies_df['date'], unit='s')
+            anomalies_df = anomalies_df.set_index(pd.DatetimeIndex(anomalies_df['date']))
+            anomalies_df = anomalies_df.resample(frequency).apply({'id': 'count'})
+            anomalies_df.rename(columns={'id': 'anomaly_count'}, inplace=True)
+            if ionosphere_performance_debug:
+                fname_out = '%s/%s.anomalies_df.csv' % (settings.SKYLINE_TMP_DIR, request_key)
+                anomalies_df.to_csv(fname_out)
+        except:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            fail_msg = 'error :: get_ionosphere_performance - could not create anomalies_df'
+            logger.error('%s' % fail_msg)
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+    fp_ids_df = []
+    fps_total_df = []
+    if fp_ids_ts:
+        try:
+            fp_ids_df = pd.DataFrame(fp_ids_ts, columns=['date', 'id'])
+            fp_ids_df['date'] = pd.to_datetime(fp_ids_df['date'], unit='s')
+            fp_ids_df = fp_ids_df.set_index(pd.DatetimeIndex(fp_ids_df['date']))
+            fp_ids_df = fp_ids_df.resample(frequency).apply({'id': 'count'})
+            fps_total_df = fp_ids_df.cumsum()
+            fp_ids_df.rename(columns={'id': 'new_fps_count'}, inplace=True)
+            fps_total_df.rename(columns={'id': 'fps_total_count'}, inplace=True)
+            if ionosphere_performance_debug:
+                fname_out = '%s/%s.fp_ids_df.csv' % (settings.SKYLINE_TMP_DIR, request_key)
+                fp_ids_df.to_csv(fname_out)
+                fname_out = '%s/%s.fps_total_df.csv' % (settings.SKYLINE_TMP_DIR, request_key)
+                fps_total_df.to_csv(fname_out)
+        except:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            fail_msg = 'error :: get_ionosphere_performance - could not create fp_ids_df'
+            logger.error('%s' % fail_msg)
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+    fps_matched_df = []
+    if fps_matched_ts:
+        try:
+            fps_matched_df = pd.DataFrame(fps_matched_ts, columns=['date', 'id'])
+            fps_matched_df['date'] = pd.to_datetime(fps_matched_df['date'], unit='s')
+            fps_matched_df = fps_matched_df.set_index(pd.DatetimeIndex(fps_matched_df['date']))
+            fps_matched_df = fps_matched_df.resample(frequency).apply({'id': 'count'})
+            fps_matched_df.rename(columns={'id': 'fps_matched_count'}, inplace=True)
+            if ionosphere_performance_debug:
+                fname_out = '%s/%s.fps_matched_df.csv' % (settings.SKYLINE_TMP_DIR, request_key)
+                fps_matched_df.to_csv(fname_out)
+        except:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            fail_msg = 'error :: get_ionosphere_performance - could not create fps_matched_df'
+            logger.error('%s' % fail_msg)
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+    layers_matched_df = []
+    if layers_matched_ts:
+        try:
+            layers_matched_df = pd.DataFrame(layers_matched_ts, columns=['date', 'id'])
+            layers_matched_df['date'] = pd.to_datetime(layers_matched_df['date'], unit='s')
+            layers_matched_df = layers_matched_df.set_index(pd.DatetimeIndex(layers_matched_df['date']))
+            layers_matched_df = layers_matched_df.resample(frequency).apply({'id': 'count'})
+            layers_matched_df.rename(columns={'id': 'layers_matched_count'}, inplace=True)
+            if ionosphere_performance_debug:
+                fname_out = '%s/%s.layers_matched_df.csv' % (settings.SKYLINE_TMP_DIR, request_key)
+                layers_matched_df.to_csv(fname_out)
+        except:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            fail_msg = 'error :: get_ionosphere_performance - could not create layers_matched_df'
+            logger.error('%s' % fail_msg)
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+
+    date_list = pd.date_range(begin_date, end_date, freq=frequency)
+    date_list = date_list.format(formatter=lambda x: x.strftime('%Y-%m-%d'))
+    # performance_df = pd.DataFrame(date_list, columns=['date'])
+    performance_df = pd.DataFrame({'date': pd.date_range(begin_date, end_date, freq=frequency), 'day': date_list})
+    # performance_df = performance_df.set_index(pd.DatetimeIndex(performance_df['date']))
+    performance_df = performance_df.set_index(['date'])
+
+    if len(anomalies_df) > 0 and report_anomalies:
+        performance_df = pd.merge(performance_df, anomalies_df, how='outer', on='date')
+        performance_df.sort_values('date')
+        performance_df['anomaly_count'] = performance_df['anomaly_count'].fillna(0)
+    if len(anomalies_df) == 0 and report_anomalies:
+        performance_df['anomaly_count'] = 0
+
+    # Report new fp count per day
+    report_new_fps = False
+    if 'new_fps' in request.args:
+        new_fps_str = request.args.get('new_fps', 'false')
+        if new_fps_str == 'true':
+            report_new_fps = True
+
+    if len(fp_ids_df) > 0 and report_new_fps:
+        performance_df = pd.merge(performance_df, fp_ids_df, how='outer', on='date')
+        performance_df.sort_values('date')
+        performance_df['new_fps_count'] = performance_df['new_fps_count'].fillna(0)
+    else:
+        performance_df['new_fps_count'] = 0
+
+    # Report new fp count per day
+    report_total_fps = False
+    if 'total_fps' in request.args:
+        total_fps_str = request.args.get('total_fps', 'false')
+        if total_fps_str == 'true':
+            report_total_fps = True
+    if len(fps_total_df) > 0 and report_total_fps:
+        performance_df = pd.merge(performance_df, fps_total_df, how='outer', on='date')
+        performance_df.sort_values('date')
+        performance_df['fps_total_count'].fillna(method='ffill', inplace=True)
+        logger.info('get_ionosphere_performance - second step of creating performance_df complete, dataframe length - %s' % str(len(performance_df)))
+    if len(fps_total_df) == 0 and report_total_fps:
+        performance_df['fps_total_count'] = 0
+
+    # Report fps_matched_count per day
+    report_fps_matched_count = False
+    if 'fps_matched_count' in request.args:
+        fps_matched_count_str = request.args.get('fps_matched_count', 'false')
+        if fps_matched_count_str == 'true':
+            report_fps_matched_count = True
+    # Report layers_matched_count per day
+    report_layers_matched_count = False
+    if 'layers_matched_count' in request.args:
+        layers_matched_count_str = request.args.get('layers_matched_count', 'false')
+        if layers_matched_count_str == 'true':
+            report_layers_matched_count = True
+    # Report sum_matches per day
+    report_sum_matches = False
+    if 'sum_matches' in request.args:
+        sum_matches_str = request.args.get('sum_matches', 'false')
+        if sum_matches_str == 'true':
+            report_sum_matches = True
+
+    if len(fps_matched_df) > 0 and report_fps_matched_count and not report_sum_matches:
+        performance_df = pd.merge(performance_df, fps_matched_df, how='outer', on='date')
+        performance_df.sort_values('date')
+        performance_df['fps_matched_count'] = performance_df['fps_matched_count'].fillna(0)
+        logger.info('get_ionosphere_performance - third step of creating performance_df complete, dataframe length - %s' % str(len(performance_df)))
+    if len(fps_matched_df) == 0 and report_fps_matched_count and not report_sum_matches:
+        performance_df['fps_matched_count'] = 0
+
+    if len(layers_matched_df) > 0 and report_layers_matched_count and not report_sum_matches:
+        performance_df = pd.merge(performance_df, layers_matched_df, how='outer', on='date')
+        performance_df.sort_values('date')
+        performance_df['layers_matched_count'] = performance_df['layers_matched_count'].fillna(0)
+        logger.info('get_ionosphere_performance - fourth step of creating performance_df complete, dataframe length - %s' % str(len(performance_df)))
+    if len(layers_matched_df) == 0 and report_layers_matched_count and not report_sum_matches:
+        performance_df['layers_matched_count'] = 0
+
+    if report_sum_matches:
+        logger.info('get_ionosphere_performance - creating matches_sum_df to calculate totals and merge with performance_df')
+        matches_sum_df = pd.DataFrame({'date': pd.date_range(begin_date, end_date, freq=frequency), 'day': date_list})
+        matches_sum_df = matches_sum_df.set_index(['date'])
+        if len(fps_matched_df) > 0:
+            matches_sum_df = pd.merge(matches_sum_df, fps_matched_df, how='outer', on='date')
+            matches_sum_df.sort_values('date')
+            matches_sum_df['fps_matched_count'] = matches_sum_df['fps_matched_count'].fillna(0)
+        if len(fps_matched_df) == 0:
+            matches_sum_df['fps_matched_count'] = 0
+        if len(layers_matched_df) > 0:
+            matches_sum_df = pd.merge(matches_sum_df, layers_matched_df, how='outer', on='date')
+            matches_sum_df.sort_values('date')
+            matches_sum_df['layers_matched_count'] = matches_sum_df['layers_matched_count'].fillna(0)
+        if len(layers_matched_df) == 0:
+            matches_sum_df['layers_matched_count'] = 0
+        matches_sum_df['total_matches'] = matches_sum_df['fps_matched_count'] + matches_sum_df['layers_matched_count']
+        sum_df = matches_sum_df[['total_matches']].copy()
+        logger.info('get_ionosphere_performance - sum_df has %s rows' % str(len(sum_df)))
+        performance_df = pd.merge(performance_df, sum_df, how='outer', on='date')
+        performance_df.sort_values('date')
+        performance_df['total_matches'] = performance_df['total_matches'].fillna(0)
+
+    if len(performance_df) > 0:
+        logger.info('get_ionosphere_performance - final step of creating performance_df with %s columns' % str(len(performance_df.columns)))
+        logger.info('get_ionosphere_performance - columns - %s' % str(performance_df.columns))
+        # performance_df = performance_df.set_index(['date'])
+        performance_df = performance_df[(performance_df.index > begin_date) & (performance_df.index <= end_date)]
+
+    # Custom title
+    if 'title' in request.args:
+        title_str = request.args.get('title', 'default')
+        if title_str != 'default':
+            if title_str == 'none':
+                plot_title = ''
+            else:
+                plot_title = title_str
+    style = []
+    if 'anomaly_count' in performance_df.columns:
+        style.append('r')
+    if 'new_fps_count' in performance_df.columns:
+        style.append('orange')
+    if 'fps_total_count' in performance_df.columns:
+        style.append('brown')
+    if 'fps_matched_count' in performance_df.columns:
+        style.append('blue')
+    if 'layers_matched_count' in performance_df.columns:
+        style.append('deepskyblue')
+    if 'total_matches' in performance_df.columns:
+        style.append('green')
+
+    # Custom title
+    if 'title' in request.args:
+        title_str = request.args.get('title', 'default')
+        if title_str != 'default':
+            if title_str == 'none':
+                plot_title = ''
+            else:
+                plot_title = title_str
+
+    # Custom size
+    width = 14
+    height = 7
+    if 'width' in request.args:
+        width_str = request.args.get('width', '14')
+        if width_str:
+            try:
+                width = int(width_str)
+            except:
+                logger.error('get_ionosphere_performance - width argument not int - %s' % str(width))
+    if 'height' in request.args:
+        height_str = request.args.get('height', '7')
+        if height_str:
+            try:
+                height = int(height_str)
+            except:
+                logger.error('get_ionosphere_performance - height argument not int - %s' % str(height))
+
+    plot_png = '%s/%s.png' % (performance_dir, request_key)
+    fig = performance_df.plot(
+        figsize=(width, height), title=plot_title, linewidth=1,
+        style=style).get_figure()
+    fig.savefig(plot_png)
+
+    performance_dict = {}
+    csv_file = '%s/%s.csv' % (performance_dir, request_key)
+
+    if len(performance_df) > 0:
+        new_performance_df = performance_df.reset_index(drop=True)
+        new_performance_df.rename(columns={'day': 'date'}, inplace=True)
+
+        logger.info('get_ionosphere_performance - created new_performance_df with %s columns' % str(new_performance_df.columns))
+        new_performance_df.to_csv(csv_file, index=False)
+        # performance_dict = new_performance_df.to_dict()
+        performance_dict = new_performance_df.to_dict('records')
+
+    if engine:
+        engine_disposal(engine)
+
+    performance = {
+        'performance': performance_dict,
+        'request_key': request_key,
+        'success': True,
+        'reason': 'data found for metric/s',
+        'plot': plot_png,
+        'csv': csv_file,
+    }
+
+    # Clean up objects to free up memory
+    try:
+        del metric_ids
+    except:
+        pass
+    try:
+        del anomalies
+    except:
+        pass
+    try:
+        del anomalies_ts
+    except:
+        pass
+    try:
+        del fp_ids
+    except:
+        pass
+    try:
+        del fp_ids_ts
+    except:
+        pass
+    try:
+        del fps_matched_ts
+    except:
+        pass
+    try:
+        del layers_matched_ts
+    except:
+        pass
+    try:
+        del anomalies_df
+    except:
+        pass
+    try:
+        del fp_ids_df
+    except:
+        pass
+    try:
+        del fps_total_df
+    except:
+        pass
+    try:
+        del fps_matched_df
+    except:
+        pass
+    try:
+        del layers_matched_df
+    except:
+        pass
+    try:
+        del date_list
+    except:
+        pass
+    try:
+        del performance_df
+    except:
+        pass
+    try:
+        del matches_sum_df
+    except:
+        pass
+    try:
+        del sum_df
+    except:
+        pass
+    try:
+        del new_performance_df
+    except:
+        pass
+    try:
+        del performance_dict
+    except:
+        pass
+
+    return performance

--- a/skyline/webapp/templates/features_profiles_matches.html
+++ b/skyline/webapp/templates/features_profiles_matches.html
@@ -40,6 +40,7 @@
 # Return matches for the last 24 hours as the default -->
 		  <li class="active"><a href="?fp_matches=true&metric=all&limit=0&from_timestamp={{ matched_from_datetime }}&order=DESC">Matches</a></li>
 	    <li><a href="?fp_validate=true&metric=all">Validate</a></li>
+		  <li><a href="?performance=true">Performance</a></li>
 		  <li><a href="/ionosphere?fp_view=true">List by metrics</a></li>
 		  <li><a href="?fp_view=true&a_dated_list=true">List by date</a></li>
 		</ul>

--- a/skyline/webapp/templates/ionosphere.html
+++ b/skyline/webapp/templates/ionosphere.html
@@ -23,6 +23,9 @@
 <!-- # @added 20180812 - Feature #2430: Ionosphere validate learnt features profiles page -->
 {% elif fp_validate %}
 		<li class="active"><span class="logo"><span class="sky">Features profiles</span> <span class="re">to validate</span></span></li>
+<!-- # @added 20210107 - Feature #3934: ionosphere_performance -->
+{% elif performance %}
+		<li class="active"><span class="logo"><span class="sky">Features profiles</span> <span class="re">performance</span></span></li>
 {% else %}
   {% if metric_files %}
 		<li><a href="/ionosphere?metric_td={{ for_metric }}">training data</a></li>
@@ -45,6 +48,9 @@
 <!-- # @added 20180812 - Feature #2430: Ionosphere validate learnt features profiles page -->
 {% elif fp_validate %}
     {% include "validate_features_profiles.html" %}
+<!-- # @added 20210107 - Feature #3934: ionosphere_performance -->
+{% elif performance %}
+    {% include "ionosphere_performance.html" %}
 {% else %}
     {% include "training_data.html" %}
 {% endif %}

--- a/skyline/webapp/templates/ionosphere_performance.html
+++ b/skyline/webapp/templates/ionosphere_performance.html
@@ -1,0 +1,224 @@
+{% block ionosphere_performance_block %}
+<!-- BEGIN /ionosphere?performance=true block -->
+{% if print_debug == 'True' %}
+<code> DEBUG </code> :: ionosphere_performance block</br>
+{% endif %}
+
+{% if display_message %}
+<code> ERROR </code></br>
+<code> message </code>: {{ display_message }}<br>
+{% endif %}
+
+<div class="navbar-header" role="navigation">
+  <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="icon-bar"></span>
+    <span class="icon-bar"></span>
+  </button>
+		<ul class="nav nav-tabs" role="view_tablist" id="view">
+		  <li><a href="/ionosphere"><span class="logo"><span class="sky">Training</span> <span class="re">data</span></span></span></a></li>
+		  <li class="active"><a href="?fp_view=true"><span class="logo"><span class="sky">Features</span> <span class="re">profiles</span></span></span></a></li>
+		</ul>
+		<div class="tab-content">
+	  	<div class="tab-pane active" id="view">
+	<br>
+  <div class="navbar-header" role="navigation">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+  </div>
+
+<!--	<div class="col-md-9 col-md-pull-3"> -->
+	<div class="col-md-12">
+		<ul class="nav nav-tabs" role="tablist" id="list_by-tabs">
+		  <li><a href="?fp_search=true&metric=all&limit=10&order=DESC">Search</a></li>
+		  <li><a href="?fp_matches=true&metric=all&limit=0&from_timestamp={{ matched_from_datetime }}&order=DESC">Matches</a></li>
+		  <li><a href="?fp_validate=true&metric=all">Validate</a></li>
+		  <li class="active"><a href="?performance=true">Performance</a></li>
+		  <li><a href="/ionosphere?fp_view=true">List by metrics</a></li>
+		  <li><a href="?fp_view=true&a_dated_list=true">List by date</a></li>
+		</ul>
+		<div class="tab-content">
+
+  		<div class="col-md-12">
+<!--  		<div class="container"> -->
+  		  <h4><span class="logo"><span class="sky">Performance ::</span> <span class="re">features profiles and layers</span></span></span></h4>
+  {% if performance_results %}
+        <button type="button" class="btn btn-info" data-toggle="collapse" data-target="#search_options">Show search options</button>
+        <div id="search_options" class="collapse">
+  {% endif %}
+        <form action="ionosphere">
+  		  <table class="table table-hover">
+  		    <thead>
+  		      <tr>
+  		        <th>Search criteria</th>
+  		        <th>filter</th>
+  		      </tr>
+  		    </thead>
+  		    <tbody>
+  		      <tr>
+  		        <td>Performance</td>
+  		        <td><select name="performance">
+                <option value="true">true</option>
+              </select></td>
+  		      </tr>
+  		      <tr>
+  		        <td>metric:</td>
+  		        <td><input type="text" name="metric" value="all" /> Metric name (if one is desired)</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Metric like</td>
+  		        <td><input type="text" name="metric_like" value="all"> (wildcards are MySQL LIKE style, % e.g. stats.app.requests.http_status_codes.% or %.http_status_codes.%)</td>
+  		      </tr>
+  		      <tr>
+  		        <td>from_timestamp</td>
+  		        <td><input type="text" name="from_timestamp" value="all"> (unix timestamp or %Y%m%d %H:%M)</td>
+  		      </tr>
+  		      <tr>
+  		        <td>until_timestamp</td>
+  		        <td><input type="text" name="until_timestamp" value="all"> (unix timestamp or %Y%m%d %H:%M)</td>
+  		      </tr>
+  		      <tr>
+  		        <td>period</td>
+              <td><select name="period">
+                <option value="daily">daily</option>
+                <option value="weekly">weekly</option>
+                <option value="monthly">monthly</option>
+              </select> Period</td>
+  		      </tr>
+  		      <tr>
+  		        <td>anomalies</td>
+              <td><select name="anomalies">
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select> Show anomalies</td>
+  		      </tr>
+  		      <tr>
+  		        <td>new_fps</td>
+                <td><select name="new_fps">
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                </select> Show new feature profiles count per period</td>
+  		      </tr>
+  		      <tr>
+                <td>total_fps</td>
+                <td><select name="total_fps">
+                  <option value="false">false</option>
+                  <option value="true">true</option>
+                </select> Show total feature profiles count for entire period</td>
+  		      </tr>
+<!--  		      <tr>
+                <td>fp_type</td>
+                <td><select name="fp_type">
+                  <option value="all">all</option>
+                  <option value="user">user generated</option>
+                  <option value="learnt">learnt</option>
+                </select> Show all or user generated or learnt features profiles in the above fps contexts</td>
+  		      </tr>
+-->
+  		      <tr>
+                <td>fps_matched_count</td>
+                <td><select name="fps_matched_count">
+                  <option value="false">false</option>
+                  <option value="true">true</option>
+                </select> Show feature profiles match count</td>
+  		      </tr>
+  		      <tr>
+                <td>layers_matched_count</td>
+                <td><select name="layers_matched_count">
+                  <option value="false">false</option>
+                  <option value="true">true</option>
+                </select> Show layers match count</td>
+  		      </tr>
+  		      <tr>
+                <td>sum_matches</td>
+                <td><select name="sum_matches">
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                </select> Sum features profile and layers match count</td>
+  		      </tr>
+  		      <tr>
+  		        <td>title</td>
+  		        <td><input type="text" name="title" value="default" /> If default the metric name or metric wildcard name will be used or use none for no title</td>
+  		      </tr>
+  		      <tr>
+  		        <td>format</td>
+                <td><select name="format">
+                  <option value="normal">normal</option>
+                  <option value="json">json</option>
+                </select> Select normal for a query on the web page or json for a json response</td>
+  		      </tr>
+  		      <tr>
+              <td>width</td>
+              <td><input type="number" name="width" min="2" max="20" value="8"> plot width</td>
+    		     </tr>
+  		      <tr>
+              <td>height</td>
+              <td><input type="number" name="height" min="1" max="20" value="4"> plot height</td>
+    		     </tr>
+  		    </tbody>
+  		  </table>
+        <br>
+        <input type="submit" value="Performance">
+      </form>
+  {% if performance_results %}
+<!-- collapse button div -->
+      </div>
+	  <h4><span class="logo"><span class="sky">Performance ::</span> <span class="re">analysis complete ::</span></span></span> OK</h4>
+    {% if performance_results['success'] %}
+	  <div class="alert alert-success">
+	    <strong>Success!</strong>
+	  </div>
+    {% else %}
+	  <div class="alert alert-warning">
+	    <strong>No results</strong> - {{ performance_results['reason'] }}
+	  </div>
+    {% endif %}
+    {% if performance_results['plot'] %}
+    <img src="ionosphere_images?image={{ performance_results['plot'] }}" alt="{{ for_metric }} Ionosphere performance">
+    <br>
+    {% endif %}
+
+
+    <br>
+	  <h4><span class="logo"><span class="sky">Performance ::</span> <span class="re">data ::</span></span></h4>
+		  <table class="table table-hover">
+		    <thead>
+		      <tr>
+		        <th>Item</th>
+		        <th>Data</th>
+		      </tr>
+		    </thead>
+		    <tbody>
+		      <tr>
+		        <td>csv file</td>
+		        <td><a href="/ionosphere_file?file={{ performance_results['csv'] }}">{{ performance_results['csv'] }}</a></td>
+		      </tr>
+		      <tr>
+		        <td>plot file</td>
+		        <td>{{ performance_results['plot'] }}</td>
+		      </tr>
+		        <td>json</td>
+		        <td>{{ performance_json_dict }}</td>
+		      </tr>
+		    </tbody>
+		  </table>
+  {% endif %}
+      </div>
+    </div> <!-- END div class="col-md-12" -->
+
+	</div>
+	</div>
+	</div>
+  </div>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<!-- END /ionosphere?performance=true block -->
+{% endblock %}

--- a/skyline/webapp/templates/search_features_profiles.html
+++ b/skyline/webapp/templates/search_features_profiles.html
@@ -42,6 +42,7 @@
 		  <li><a href="?fp_matches=true&metric=all&limit=0&from_timestamp={{ matched_from_datetime }}&order=DESC">Matches</a></li>
 		  <li><a href="?fp_validate=true&metric=all">Validate</a></li>
 		  <li><a href="/ionosphere?fp_view=true">List by metrics</a></li>
+		  <li><a href="?performance=true">Performance</a></li>
 		  <li><a href="?fp_view=true&a_dated_list=true">List by date</a></li>
 		</ul>
 		<div class="tab-content">

--- a/skyline/webapp/templates/validate_features_profiles.html
+++ b/skyline/webapp/templates/validate_features_profiles.html
@@ -41,6 +41,7 @@
 # Return matches for the last 24 hours as the default -->
 		  <li><a href="?fp_matches=true&metric=all&limit=0&from_timestamp={{ matched_from_datetime }}&order=DESC">Matches</a></li>
 		  <li class="active"><a href="?fp_validate=true&metric=all">Validate</a></li>
+		  <li><a href="?performance=true">Performance</a></li>
 		  <li><a href="/ionosphere?fp_view=true">List by metrics</a></li>
 		  <li><a href="?fp_view=true&a_dated_list=true">List by date</a></li>
 		</ul>

--- a/utils/continuity.py
+++ b/utils/continuity.py
@@ -63,23 +63,23 @@ def check_continuity(metric, mini=False):
 
 if __name__ == "__main__":
     length, total_sum, start, end, duration, bad, missing = check_continuity(metric)
-    print ""
-    print "Stats for full %s:" % metric
-    print "Length of %s" % length
-    print "Total sum of last 50 datapoints: %s" % total_sum
-    print "Start time: %s" % start
-    print "End time: %s" % end
-    print "Duration: %.2f hours" % duration
-    print "Number of missing data periods: %s" % bad
-    print "Total duration of missing data in seconds: %s" % missing
+    print("")
+    print("Stats for full %s:" % metric)
+    print("Length of %s" % length)
+    print("Total sum of last 50 datapoints: %s" % total_sum)
+    print("Start time: %s" % start)
+    print("End time: %s" % end)
+    print("Duration: %.2f hours" % duration)
+    print("Number of missing data periods: %s" % bad)
+    print("Total duration of missing data in seconds: %s" % missing)
 
     length, total_sum, start, end, duration, bad, missing = check_continuity(metric, True)
-    print ""
-    print "Stats for mini %s:" % metric
-    print "Length: %s" % length
-    print "Total sum of last 50 datapoints: %s" % total_sum
-    print "Start time: %s" % start
-    print "End time: %s" % end
-    print "Duration: %.2f hours" % duration
-    print "Number of missing data periods: %s" % bad
-    print "Total duration of missing data in seconds: %s" % missing
+    print("")
+    print("Stats for mini %s:" % metric)
+    print("Length: %s" % length)
+    print("Total sum of last 50 datapoints: %s" % total_sum)
+    print("Start time: %s" % start)
+    print("End time: %s" % end)
+    print("Duration: %.2f hours" % duration)
+    print("Number of missing data periods: %s" % bad)
+    print("Total duration of missing data in seconds: %s" % missing)


### PR DESCRIPTION
IssueID #3934: ionosphere_performance
IssueID #3850: webapp - yhat_values API endpoint
IssueID #3936: Allow for FLUX_API_KEYS rotation

- Added an ionosphere_performance page and functions to webapp to analyse,
  visualise and report on the performance of ionosphere on metrics and namespaces
- Change webapp yhat_values API endpoint to return 204 on no data instead of 404 (3850)
- Allow for key and namespace mapped FLUX_API_KEYS so as to allow a namespace to
  have multiple keys which allows for key rotation
- Update docs
- misc docs corrections, modifications and bandit additions

Added:
skyline/webapp/templates/ionosphere_performance.html
Modified:
docs/analyzer.rst
docs/panorama.rst
docs/running-multiple-skylines.rst
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/features_profiles_matches.html
skyline/webapp/templates/ionosphere.html
skyline/webapp/templates/search_features_profiles.html
skyline/webapp/templates/validate_features_profiles.html
skyline/webapp/webapp.py
utils/continuity.py