### PR TITLE
Downgrade xlrd

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -650,7 +650,9 @@ falcon==2.0.0
 #                   Feature #3538: webapp - upload_data endpoint
 # @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
 #xlrd==1.2.0
-xlrd==2.0.1
+# @modified 20210121 - Bug #3944: xlrd-2.0.1 removed support for xlsx format
+#xlrd==2.0.1
+xlrd==1.2.0
 
 # @added 20200520 - Feature #3550: flux.uploaded_data_worker
 # pin to 0.1.6 until pandas-1.0.3 has been thoroughly tested

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ urllib3==1.26.2
 graphyte==1.6.0
 statsd==3.3.0
 falcon==2.0.0
-xlrd==2.0.1
+xlrd==1.2.0
 pandas_log==0.1.6; python_version >= '3.2'
 timeout-decorator==0.4.1
 matrixprofile==1.1.4


### PR DESCRIPTION
IssueID #3944: xlrd-2.0.1 removed support for xlsx format

- Update requirements to use xlrd-1.2.0 again

Modified:
dev-requirements.txt
requirements.txt