### PR TITLE
Tune flux populate_metric_worker

### DIFF
--- a/docs/upload-data-to-flux.rst
+++ b/docs/upload-data-to-flux.rst
@@ -177,7 +177,7 @@ follows.  Note that in this instance you would need a your
 .. code-block:: python
 
     FLUX_UPLOADS_KEYS = {
-        'temp_monitoring.warehouse.2.012383': '484166bf-df66-4f7d-ad4a-9336da9ef620',
+        '484166bf-df66-4f7d-ad4a-9336da9ef620': 'temp_monitoring.warehouse.2.012383',
     }
 
 curl request.

--- a/skyline/snab/snab_flux_load_test.py
+++ b/skyline/snab/snab_flux_load_test.py
@@ -251,7 +251,7 @@ class SNAB_flux_load_test(Thread):
         while len(snab_flux_load_test_metrics) < SNAB_FLUX_LOAD_TEST_METRICS:
             new_uuid = str(uuid.uuid4())
             new_metric_uuid = new_uuid.replace('-', '.')
-            slot = str(round(random.random(), 2))
+            slot = str(round(random.random(), 2))  # nosec
             new_metric = '%s.%s.%s' % (SNAB_FLUX_LOAD_TEST_NAMESPACE_PREFIX, slot, new_metric_uuid)
             snab_flux_load_test_metrics.append(new_metric)
             # Add to the snab_flux_load_test_metrics_set Redis set
@@ -304,7 +304,7 @@ class SNAB_flux_load_test(Thread):
                     'metrics': []
                 }
             if post_count < SNAB_FLUX_LOAD_TEST_METRICS_PER_POST:
-                post_data_dict['metrics'].append({'metric': metric, 'timestamp': str(epoch_timestamp), 'value': str(round(random.random(), 2))})
+                post_data_dict['metrics'].append({'metric': metric, 'timestamp': str(epoch_timestamp), 'value': str(round(random.random(), 2))})  # nosec
                 post_count += 1
             if post_count == SNAB_FLUX_LOAD_TEST_METRICS_PER_POST:
                 response = None


### PR DESCRIPTION
IssueID #3864: flux - try except everything
IssueID #3068: SNAB

- Bring into line with flux worker performance changes, tune flux
  populate_metric_worker like flux upload_data in terms of pickle limits
- Added bandit nosec on random.random()

Modified:
docs/upload-data-to-flux.rst
skyline/flux/populate_metric_worker.py
skyline/snab/snab_flux_load_test.py