### PR TITLE
Update Jinja

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -56,7 +56,9 @@ itsdangerous==1.1.0
 #Jinja2==2.10
 # @modified 20200701 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #Jinja2==2.10.1
-Jinja2==2.11.2
+# @modified 20210202 - Task #3960: SNYK-PYTHON-JINJA2-1012994
+#Jinja2==2.11.2
+Jinja2==2.11.3
 
 # @modified 20190412 - Task #2926: Update dependencies
 #MarkupSafe==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ docutils==0.16
 lockfile==0.12.2
 python-daemon==2.2.4
 itsdangerous==1.1.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 MarkupSafe==1.1.1
 Werkzeug==1.0.1
 click==7.1.2


### PR DESCRIPTION
IssueID #3960: SNYK-PYTHON-JINJA2-1012994

- Update to Jinja-2.11.3 as per:
  https://snyk.io/vuln/SNYK-PYTHON-JINJA2-1012994
  https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28493
  https://github.com/pallets/jinja/blob/ab81fd9c277900c85da0c322a2ff9d68a235b2e6/src/jinja2/utils.py#L20
  https://github.com/pallets/jinja/pull/1343

Modified:
dev-requirements.txt
requirements.txt