### PR TITLE
Handle secondary algorithms in yhat_values and ionosphere_performance…

### DIFF
--- a/docs/vista.rst
+++ b/docs/vista.rst
@@ -37,6 +37,12 @@ This will result in a new metric in Graphite named
 `vista.stats.cumulative.procs_running`, that will have its own time series data
 for seasonal analysis, correlation and visualisation.
 
+.. note:: If you create a metric from a Graphite function/s on metrics your
+  ``populate_at_resolutions`` tuple should be only be set to the duration of the
+  first Graphite retention.  A metric created from function/s over metrics from
+  aggregated data retentions will not have the result a user may expect as the
+  function is applied to the aggregated values.
+
 Important note - Intended use
 -----------------------------
 
@@ -250,8 +256,8 @@ The setting consists of a tuple of tuples, like the Analyzer
     VISTA_FETCH_METRICS = (
         # (remote_host, remote_host_type, frequency, remote_target, graphite_target, uri, namespace_prefix, api_key, token, user, password, (populate_at_resolution_1, populate_at_resolution_2, ...)),
         # Example with no authentication
-        ('https://graphite.example.org', 'graphite', 60, 'stats.web01.cpu.user', 'stats.web01.cpu.user', '/render/?from=-10minutes&format=json&target=', 'vista.graphite_example_org', None, None, None, None, ('90days', '7days', '24hours', '6hours')),
-        ('https://graphite.example.org', 'graphite', 60, 'sumSeries(stats.*.cpu.user)', 'stats.cumulative.cpu.user', '/render/?from=-10minutes&format=json&target=', 'vista.graphite_example_org', None, None, None, None, ('90days', '7days', '24hours', '6hours')),
+        ('https://graphite.example.org', 'graphite', 60, 'stats.web01.cpu.user', 'stats.web01.cpu.user', '/render/?from=-10minutes&until=-1minutes&format=json&target=', 'vista.graphite_example_org', None, None, None, None, ('90days', '7days', '24hours', '6hours')),
+        ('https://graphite.example.org', 'graphite', 60, 'sumSeries(stats.*.cpu.user)', 'stats.cumulative.cpu.user', '/render/?from=-24hours&until=-1minutes&format=json&target=', 'vista.graphite_example_org', None, None, None, None, ('6days')),
         ('https://graphite.example.org', 'graphite', 3600, 'swell.tar.hm0', 'swell.tar.hm0', '/render/?from=-120minutes&format=json&target=', 'graphite_example_org', None, None, None, None, ('90days', '7days', '24hours', '6hours')),
         ('http://prometheus.example.org:9090', 'prometheus', 60, 'node_load1', 'node_load1', 'default', 'vista.prometheus_example_org', None, None, None, None, , ('15d')),
         ('http://prometheus.example.org:9090', 'prometheus', 60, 'node_network_transmit_bytes_total{device="eth0"}', 'node_network_transmit_bytes_total.eth0', 'default', 'vista.prometheus_example_org', None, None, None, None, , ('15d',)),

--- a/skyline/analyzer/metrics_manager.py
+++ b/skyline/analyzer/metrics_manager.py
@@ -192,6 +192,16 @@ if HORIZON_SHARDS:
     number_of_horizon_shards = len(HORIZON_SHARDS)
     HORIZON_SHARD = HORIZON_SHARDS[this_host]
 
+# @added 20210202 - Feature #3934: ionosphere_performance
+try:
+    IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE = settings.IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE
+except:
+    IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE = False
+try:
+    IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE_DEPTH = int(settings.IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE_DEPTH)
+except:
+    IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE_DEPTH = 0
+
 skyline_app_graphite_namespace = 'skyline.%s%s' % (skyline_app, SERVER_METRIC_PATH)
 
 full_uniques = '%sunique_metrics' % settings.FULL_NAMESPACE

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -527,10 +527,11 @@ skyline.analyzer.skyline-1.algorithm_breakdown.ks_test.timing.times_run
 
 Example:
 
-CHECK_AIRGAPS = [
-    'remote_hosts',
-    'external_hosts.dc1',
-]
+    CHECK_AIRGAPS = [
+        'remote_hosts',
+        'external_hosts.dc1',
+    ]
+
 """
 
 SKIP_AIRGAPS = []
@@ -554,11 +555,12 @@ skyline.analyzer.skyline-1.algorithm_breakdown.ks_test.timing.times_run
 
 Example:
 
-SKIP_AIRGAPS = [
-    'carbon',
-    'skyline',
-    'stats',
-]
+    SKIP_AIRGAPS = [
+        'carbon',
+        'skyline',
+        'stats',
+    ]
+
 """
 
 IDENTIFY_UNORDERED_TIMESERIES = False
@@ -2714,6 +2716,31 @@ IONOSPHERE_UNTRAINABLES = []
 :vartype IONOSPHERE_UNTRAINABLES: list
 """
 
+IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE = False
+"""
+:var IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE: whether metrics_manager should
+    populate the performance cache items at the beginning of the data.  Under
+    normal circumstances this is not required, it just make the Ionosphere
+    performance graphs build quicker.
+:vartype IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE: boolean
+"""
+
+IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE_DEPTH = 0
+"""
+:var IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE_DEPTH: namespace element depth
+    to cache.  If IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE is enabled this is
+    the number of namespace elements (0 indexed) to populate the cache to
+    (including :mod:`settings.FULL_NAMESPACE` for which we shall use ``metrics.``
+    in the example below).  For example take the metric namespaces,
+    metrics.stats.* and metrics.telegraf.* if you wanted to cache the
+    performance data for the metrics.stats.* namespace as a whole and the
+    metrics.telegraf.* namespace as a whole, you would set this to 1.
+    0 would cache perfromance data for all metrics
+    1 would cache perfromance data for the sum of all metrics.*, and sum of all
+    metrics.stats.* and sum of all metrics.telegraf.*. e.g. 0 is implied
+:vartype IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE_DEPTH: int
+"""
+
 MEMCACHE_ENABLED = False
 """
 :var MEMCACHE_ENABLED: Enables the use of memcache in Ionosphere to optimise
@@ -2981,14 +3008,16 @@ FLUX_API_KEYS = {}
     Each API key must be a 32 character alphanumeric string [a-Z][0-9]
     The trailing dot of the namespace prefix must not be specified it will be
     automatically added as the separator between the namespace prefix and the
-    metric name.
+    metric name. For more see
+    https://earthgecko-skyline.readthedocs.io/en/latest/upload-data-to-flux.html
 :vartype FLUX_API_KEYS: dict
 
 - **Example**::
 
     FLUX_API_KEYS = {
-        'ZlJXpBL6QVuZg5KL4Vwrccvl8Bl3bBjC': None,
-        'KYRsv508FJpVg7pr11vnZTbeu11UvUqR': 'warehouse-1'
+        'ZlJXpBL6QVuZg5KL4Vwrccvl8Bl3bBjC': 'warehouse-1',
+        'KYRsv508FJpVg7pr11vnZTbeu11UvUqR': 'warehouse-1'  # allow multiple keys for a namesapce to allow for key rotation
+        'ntG9Tlk74FeV7Muy65EdHbZ07Mpvj7Gg': 'warehouse-2.floor.1'
     }
 
 """

--- a/skyline/skyline.sql
+++ b/skyline/skyline.sql
@@ -406,7 +406,11 @@ Added fp_count and fp_checked
 */
   `user_id` INT DEFAULT NULL COMMENT 'the user id that validated the match',
   PRIMARY KEY (id),
+/*
+# @modified 20210201 - Feature #3934: ionosphere_performance
   INDEX `features_profile_matched` (`id`,`fp_id`))
+*/
+  INDEX `features_profile_matched` (`id`,`fp_id`,`metric_timestamp`))
   ENGINE=InnoDB;
 
 /*
@@ -482,7 +486,11 @@ Added layers_count and layers_checked
 */
   `user_id` INT DEFAULT NULL COMMENT 'the user id that validated the match',
   PRIMARY KEY (id),
+/*
+# @modified 20210201 - Feature #3934: ionosphere_performance
   INDEX `layers_matched` (`id`,`layer_id`,`fp_id`,`metric_id`))
+*/
+  INDEX `layers_matched` (`id`,`layer_id`,`fp_id`,`metric_id`,`anomaly_timestamp`))
   ENGINE=InnoDB;
 
 # @added 20180413 - Branch #2270: luminosity

--- a/skyline/webapp/ionosphere_backend.py
+++ b/skyline/webapp/ionosphere_backend.py
@@ -39,6 +39,8 @@ from skyline_functions import (
     mkdir_p, get_graphite_metric, write_data_to_file,
     # @added 20201213 - Feature #3890: metrics_manager - sync_cluster_files
     get_redis_conn_decoded,
+    # @added 20210129 - Feature #3934: ionosphere_performance
+    get_redis_conn,
 )
 
 # @added 20200813 - Feature #3670: IONOSPHERE_CUSTOM_KEEP_TRAINING_TIMESERIES_FOR
@@ -6416,7 +6418,13 @@ def expected_features_profiles_dirs():
 
 
 # @added 20210107 - Feature #3934: ionosphere_performance
-def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timestamp, format):
+def get_ionosphere_performance(
+        metric, metric_like, from_timestamp, until_timestamp, format,
+        # @added 20210128 - Feature #3934: ionosphere_performance
+        # Improve performance and pass arguments to get_ionosphere_performance
+        # for cache key
+        anomalies, new_fps, fps_matched_count, layers_matched_count,
+        sum_matches, title, period, height, width, fp_type, timezone_str):
     """
     Analyse the performance of Ionosphere on a metric or metric namespace and
     create the graph resources or json data as required.
@@ -6425,35 +6433,200 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
 
     """
     import datetime
+    import pytz
     import pandas as pd
+    from math import nan
 
     ionosphere_performance_debug = False
     determine_start_timestamp = False
+    redis_conn = None
+    redis_conn_decoded = None
+
+    # @added 20210202 - Feature #3934: ionosphere_performance
+    # Handle user timezone
+    tz_from_timestamp_datetime_obj = None
+    tz_until_timestamp_datetime_obj = None
+    utc_epoch_timestamp = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone(datetime.timedelta(seconds=0)))
+    determine_timezone_start_date = False
+    determine_timezone_end_date = False
+    user_timezone = pytz.timezone(timezone_str)
+    utc_timezone = pytz.timezone('UTC')
 
     if from_timestamp == 0:
         start_timestamp = 0
         determine_start_timestamp = True
     if from_timestamp != 0:
         if ":" in from_timestamp:
-            new_from_timestamp = time.mktime(datetime.datetime.strptime(from_timestamp, '%Y%m%d %H:%M').timetuple())
+            # @modified 20210202 - Feature #3934: ionosphere_performance
+            # Handle user timezone
+            if timezone_str == 'UTC':
+                new_from_timestamp = time.mktime(datetime.datetime.strptime(from_timestamp, '%Y%m%d %H:%M').timetuple())
+                logger.info('get_ionosphere_performance - new_from_timestamp - %s' % str(new_from_timestamp))
+            else:
+                utc_from_timestamp = time.mktime(datetime.datetime.strptime(from_timestamp, '%Y%m%d %H:%M').timetuple())
+                logger.info('get_ionosphere_performance - utc_from_timestamp - %s' % str(utc_from_timestamp))
+                from_timestamp_datetime_obj = datetime.datetime.strptime(from_timestamp, '%Y%m%d %H:%M')
+                logger.info('get_ionosphere_performance - from_timestamp_datetime_obj - %s' % str(from_timestamp_datetime_obj))
+                tz_offset = pytz.timezone(timezone_str).localize(from_timestamp_datetime_obj).strftime('%z')
+                tz_from_date = '%s:00 %s' % (from_timestamp, tz_offset)
+                logger.info('get_ionosphere_performance - tz_from_date - %s' % str(tz_from_date))
+                tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y%m%d %H:%M:%S %z')
+                tz_epoch_timestamp = int((tz_from_timestamp_datetime_obj - utc_epoch_timestamp).total_seconds())
+                new_from_timestamp = tz_epoch_timestamp
+                # new_from_timestamp = time.mktime(datetime.datetime.strptime(tz_from_timestamp, '%Y%m%d %H:%M:%S %z').timetuple())
+                logger.info('get_ionosphere_performance - new_from_timestamp - %s' % str(new_from_timestamp))
+                determine_timezone_start_date = True
             start_timestamp = int(new_from_timestamp)
         if from_timestamp == 'all':
             start_timestamp = 0
             determine_start_timestamp = True
     if until_timestamp and until_timestamp != 'all':
         if ":" in until_timestamp:
-            new_until_timestamp = time.mktime(datetime.datetime.strptime(until_timestamp, '%Y%m%d %H:%M').timetuple())
+            if timezone_str == 'UTC':
+                new_until_timestamp = time.mktime(datetime.datetime.strptime(until_timestamp, '%Y%m%d %H:%M').timetuple())
+            else:
+                until_timestamp_datetime_obj = datetime.datetime.strptime(until_timestamp, '%Y%m%d %H:%M')
+                tz_offset = pytz.timezone(timezone_str).localize(until_timestamp_datetime_obj).strftime('%z')
+                tz_until_date = '%s:00 %s' % (until_timestamp, tz_offset)
+                logger.info('get_ionosphere_performance - tz_until_date - %s' % str(tz_until_date))
+                tz_until_timestamp_datetime_obj = datetime.datetime.strptime(tz_until_date, '%Y%m%d %H:%M:%S %z')
+                tz_epoch_timestamp = int((tz_until_timestamp_datetime_obj - utc_epoch_timestamp).total_seconds())
+                new_from_timestamp = tz_epoch_timestamp
+                # new_from_timestamp = time.mktime(datetime.datetime.strptime(tz_until_timestamp, '%Y%m%d %H:%M:%S %z').timetuple())
             end_timestamp = int(new_until_timestamp)
+
+    determine_timezone_end_date = False
     if until_timestamp == 'all':
         end_timestamp = int(time.time())
+        determine_timezone_end_date = True
     if until_timestamp == 0:
         end_timestamp = int(time.time())
+        determine_timezone_end_date = True
 
     start_timestamp_str = str(start_timestamp)
     end_timestamp_str = str(end_timestamp)
 
-    begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
-    end_date = datetime.datetime.utcfromtimestamp(end_timestamp).strftime('%Y-%m-%d')
+    if timezone_str == 'UTC':
+        begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+        end_date = datetime.datetime.utcfromtimestamp(end_timestamp).strftime('%Y-%m-%d')
+    else:
+        if determine_timezone_start_date:
+            logger.info('get_ionosphere_performance - determine_timezone_start_date - True')
+            # non_tz_start_datetime_object = datetime.datetime.utcfromtimestamp(start_timestamp)
+            # logger.info('get_ionosphere_performance - non_tz_start_datetime_object - %s' % str(non_tz_start_datetime_object))
+            # tz_start_datetime_object = utc_timezone.localize(non_tz_start_datetime_object).astimezone(user_timezone)
+            # logger.info('get_ionosphere_performance - tz_end_datetime_object - %s' % str(tz_start_datetime_object))
+            begin_date = tz_from_timestamp_datetime_obj.strftime('%Y-%m-%d')
+            logger.info('get_ionosphere_performance - begin_date with %s timezone applied - %s' % (timezone_str, str(begin_date)))
+        else:
+            begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+        if determine_timezone_end_date:
+            logger.info('get_ionosphere_performance - determine_timezone_end_date - True')
+            non_tz_end_datetime_object = datetime.datetime.utcfromtimestamp(end_timestamp)
+            logger.info('get_ionosphere_performance - non_tz_end_datetime_object - %s' % str(non_tz_end_datetime_object))
+            tz_end_datetime_object = utc_timezone.localize(non_tz_end_datetime_object).astimezone(user_timezone)
+            logger.info('get_ionosphere_performance - tz_end_datetime_object - %s' % str(tz_end_datetime_object))
+            end_date = tz_end_datetime_object.strftime('%Y-%m-%d')
+            logger.info('get_ionosphere_performance - end_date with %s timezone applied - %s' % (timezone_str, str(end_date)))
+        else:
+            logger.info('get_ionosphere_performance - determine_timezone_end_date - False')
+            end_date = datetime.datetime.utcfromtimestamp(end_timestamp).strftime('%Y-%m-%d')
+
+    original_begin_date = begin_date
+
+    # Determine period
+    frequency = 'D'
+    if 'period' in request.args:
+        period = request.args.get('period', 'daily')
+        if period == 'daily':
+            frequency = 'D'
+            extended_end_timestamp = end_timestamp + 86400
+        if period == 'weekly':
+            frequency = 'W'
+            extended_end_timestamp = end_timestamp + (86400 * 7)
+        if period == 'monthly':
+            frequency = 'M'
+            extended_end_timestamp = end_timestamp + (86400 * 30)
+    extended_end_date = datetime.datetime.utcfromtimestamp(extended_end_timestamp).strftime('%Y-%m-%d')
+
+    remove_prefix = False
+    try:
+        remove_prefix_str = request.args.get('remove_prefix', 'false')
+        if remove_prefix_str != 'false':
+            remove_prefix = True
+    except:
+        pass
+    # Allow for the removal of a prefix from the metric name
+    use_metric_name = metric
+    if remove_prefix:
+        try:
+            if remove_prefix_str.endswith('.'):
+                remove_prefix = '%s' % remove_prefix_str
+            else:
+                remove_prefix = '%s.' % remove_prefix_str
+            use_metric_name = metric.replace(remove_prefix, '')
+        except Exception as e:
+            logger.error('error :: failed to remove prefix %s from %s - %s' % (str(remove_prefix_str), metric, e))
+
+    # @added 20210129 - Feature #3934: ionosphere_performance
+    # Improve performance and pass arguments to get_ionosphere_performance
+    # for cache key
+    yesterday_timestamp = end_timestamp - 86400
+    yesterday_end_date = datetime.datetime.utcfromtimestamp(yesterday_timestamp).strftime('%Y-%m-%d')
+    metric_like_str = str(metric_like)
+    metric_like_wildcard = metric_like_str.replace('.%', '')
+    # @modified 20210202 - Feature #3934: ionosphere_performance
+    # Handle user timezone
+    yesterday_data_cache_key = 'performance.%s.metric.%s.metric_like.%s.begin_date.%s.tz.%s.anomalies.%s.new_fps.%s.fps_matched_count.%s.layers_matched_count.%s.sum_matches.%s.period.%s.fp_type.%s' % (
+        str(yesterday_end_date), str(metric), metric_like_wildcard, str(begin_date),
+        str(timezone_str), str(anomalies), str(new_fps), str(fps_matched_count),
+        str(layers_matched_count), str(sum_matches), str(period), str(fp_type))
+    logger.info('get_ionosphere_performance - yesterday_data_cache_key - %s' % yesterday_data_cache_key)
+
+    try:
+        redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+    except:
+        logger.error(traceback.format_exc())
+        logger.error('error :: get_ionosphere_performance :: get_redis_conn_decoded failed')
+    yesterday_data_raw = None
+    try:
+        yesterday_data_raw = redis_conn_decoded.get(yesterday_data_cache_key)
+    except:
+        trace = traceback.format_exc()
+        fail_msg = 'error :: get_ionosphere_performance - could not get Redis data for - %s' % yesterday_data_cache_key
+        logger.error(trace)
+        logger.error(fail_msg)
+    yesterday_data = None
+    if yesterday_data_raw:
+        try:
+            yesterday_data = literal_eval(yesterday_data_raw)
+        except:
+            trace = traceback.format_exc()
+            fail_msg = 'error :: get_ionosphere_performance - could not get literal_eval Redis data from key - %s' % yesterday_data_cache_key
+            logger.error(trace)
+            logger.error(fail_msg)
+    if yesterday_data:
+        logger.info('get_ionosphere_performance - using cache data from yesterday with %s items' % str(len(yesterday_data)))
+        new_from = '%s 23:59:59' % yesterday_end_date
+        # @modified 20210202 - Feature #3934: ionosphere_performance
+        # Handle user timezone
+        if timezone_str == 'UTC':
+            new_from_timestamp = time.mktime(datetime.datetime.strptime(new_from, '%Y-%m-%d %H:%M:%S').timetuple())
+            start_timestamp = int(new_from_timestamp) + 1
+            begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
+        else:
+            tz_new_from_timestamp_datetime_obj = datetime.datetime.strptime(new_from, '%Y-%m-%d %H:%M:%S')
+            tz_offset = pytz.timezone(timezone_str).localize(tz_new_from_timestamp_datetime_obj).strftime('%z')
+            tz_from_timestamp = '%s %s' % (new_from, tz_offset)
+            new_from_timestamp = time.mktime(datetime.datetime.strptime(tz_from_timestamp, '%Y-%m-%d %H:%M:%S %z').timetuple())
+            start_timestamp = int(new_from_timestamp) + 1
+            begin_date = tz_new_from_timestamp_datetime_obj.strftime('%Y-%m-%d')
+
+        logger.info('get_ionosphere_performance - using cache data from yesterday, set new start_timestamp: %s, begin_date: %s' % (
+            str(start_timestamp), str(begin_date)))
+        determine_start_timestamp = False
+    else:
+        logger.info('get_ionosphere_performance - no cache data for yesterday_data')
 
     try:
         engine, fail_msg, trace = get_an_engine()
@@ -6478,17 +6651,6 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
             engine_disposal(engine)
         raise  # to webapp to return in the UI
 
-    # Determine period
-    frequency = 'D'
-    if 'period' in request.args:
-        period = request.args.get('period', 'daily')
-        if period == 'daily':
-            frequency = 'D'
-        if period == 'weekly':
-            frequency = 'W'
-        if period == 'monthly':
-            frequency = 'M'
-
     metric_id = None
     metric_ids = []
     if metric_like != 'all':
@@ -6496,8 +6658,9 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         logger.info('get_ionosphere_performance - metric_like - %s' % metric_like_str)
         metrics_like_query = text("""SELECT id FROM metrics WHERE metric LIKE :like_string""")
         metric_like_wildcard = metric_like_str.replace('.%', '')
-        request_key = '%s.%s.%s.%s.%s' % (metric_like_wildcard, begin_date, end_date, frequency, format)
+        request_key = '%s.%s.%s.%s' % (metric_like_wildcard, begin_date, end_date, frequency)
         plot_title = '%s - %s' % (metric_like_wildcard, period)
+        logger.info('get_ionosphere_performance - metric like query, cache key being generated from request key - %s' % request_key)
         try:
             connection = engine.connect()
             result = connection.execute(metrics_like_query, like_string=metric_like_str)
@@ -6529,8 +6692,22 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
                 logger.info('get_ionosphere_performance - determined start_timestamp - %s' % str(start_timestamp))
                 begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
                 logger.info('get_ionosphere_performance - determined begin_date - %s' % str(begin_date))
+
+                # @added 20210203 - Feature #3934: ionosphere_performance
+                # Handle user timezone
+                if timezone_str != 'UTC':
+                    logger.info('get_ionosphere_performance - determining %s datetime from UTC start_timestamp - %s' % (timezone_str, str(start_timestamp)))
+                    from_timestamp_datetime_obj = datetime.datetime.strptime(start_timestamp, '%Y-%m-%d %H:%M:%S')
+                    logger.info('get_ionosphere_performance - from_timestamp_datetime_obj - %s' % str(from_timestamp_datetime_obj))
+                    tz_offset = pytz.timezone(timezone_str).localize(from_timestamp_datetime_obj).strftime('%z')
+                    tz_from_date = '%s %s' % (from_timestamp, tz_offset)
+                    logger.info('get_ionosphere_performance - tz_from_date - %s' % str(tz_from_date))
+                    tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y%m%d %H:%M:%S %z')
+                    begin_date = tz_from_timestamp_datetime_obj.strftime('%Y-%m-%d')
+                    logger.info('get_ionosphere_performance - begin_date with %s timezone applied - %s' % (timezone_str, str(begin_date)))
+
                 determine_start_timestamp = False
-                request_key = '%s.%s.%s.%s.%s' % (metric_like_wildcard, begin_date, end_date, frequency, format)
+                request_key = '%s.%s.%s.%s' % (metric_like_wildcard, begin_date, end_date, frequency)
             except:
                 trace = traceback.format_exc()
                 logger.error(trace)
@@ -6544,8 +6721,9 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
     if not metric_ids:
         # stmt = select([metrics_table]).where(metrics_table.c.id > 0)
         if metric == 'all':
-            request_key = 'all.%s.%s.%s.%s' % (begin_date, end_date, frequency, format)
+            request_key = 'all.%s.%s.%s' % (begin_date, end_date, frequency)
             plot_title = 'All metrics - %s' % period
+            logger.info('get_ionosphere_performance - metric all query, cache key being generated from request key - %s' % request_key)
             # If the from_timestamp is 0 or all
             if determine_start_timestamp:
                 try:
@@ -6563,8 +6741,23 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
                     logger.info('get_ionosphere_performance - determined start_timestamp - %s' % str(start_timestamp))
                     begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
                     logger.info('get_ionosphere_performance - determined begin_date - %s' % str(begin_date))
+
+                    # @added 20210203 - Feature #3934: ionosphere_performance
+                    # Handle user timezone
+                    if timezone_str != 'UTC':
+                        logger.info('get_ionosphere_performance - determining %s datetime from UTC start_timestamp - %s' % (timezone_str, str(start_timestamp)))
+                        from_timestamp_datetime_obj = datetime.datetime.strptime(start_timestamp, '%Y-%m-%d %H:%M:%S')
+                        logger.info('get_ionosphere_performance - from_timestamp_datetime_obj - %s' % str(from_timestamp_datetime_obj))
+                        tz_offset = pytz.timezone(timezone_str).localize(from_timestamp_datetime_obj).strftime('%z')
+                        tz_from_date = '%s %s' % (from_timestamp, tz_offset)
+                        logger.info('get_ionosphere_performance - tz_from_date - %s' % str(tz_from_date))
+                        tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y%m%d %H:%M:%S %z')
+                        begin_date = tz_from_timestamp_datetime_obj.strftime('%Y-%m-%d')
+                        logger.info('get_ionosphere_performance - begin_date with %s timezone applied - %s' % (timezone_str, str(begin_date)))
+
                     determine_start_timestamp = False
-                    request_key = 'all.%s.%s.%s.%s' % (begin_date, end_date, frequency, format)
+                    request_key = 'all.%s.%s.%s' % (begin_date, end_date, frequency)
+                    logger.info('get_ionosphere_performance - metric all query, determine_start_timestamp cache key being generated from request key - %s' % request_key)
                 except:
                     trace = traceback.format_exc()
                     logger.error(trace)
@@ -6572,19 +6765,37 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
                     if engine:
                         engine_disposal(engine)
                     return {}
+            try:
+                request_key = '%s.%s.%s.%s' % (metric, begin_date, end_date, frequency)
+                plot_title = '%s - %s' % (use_metric_name, period)
+                logger.info('get_ionosphere_performance - metric all query, cache key being generated from request key - %s' % request_key)
+                connection = engine.connect()
+                stmt = select([metrics_table]).where(metrics_table.c.id > 0)
+                result = connection.execute(stmt)
+                for row in result:
+                    metric_id_str = row['id']
+                    r_metric_id = int(metric_id_str)
+                    metric_ids.append(r_metric_id)
+                connection.close()
+            except:
+                logger.error(traceback.format_exc())
+                logger.error('error :: get_ionosphere_performance - could not determine metric ids from metrics')
+                if engine:
+                    engine_disposal(engine)
+                raise
 
         if metric != 'all':
             logger.info('get_ionosphere_performance - metric - %s' % metric)
             try:
-                request_key = '%s.%s.%s.%s.%s' % (metric, begin_date, end_date, frequency, format)
-                plot_title = '%s - %s' % (metric, period)
+                request_key = '%s.%s.%s.%s' % (metric, begin_date, end_date, frequency)
+                plot_title = '%s - %s' % (use_metric_name, period)
+                logger.info('get_ionosphere_performance - metric query, cache key being generated from request key - %s' % request_key)
                 connection = engine.connect()
                 stmt = select([metrics_table]).where(metrics_table.c.metric == str(metric))
                 result = connection.execute(stmt)
                 for row in result:
                     metric_id_str = row['id']
                     metric_id = int(metric_id_str)
-                    # metric_ids.append(metric_id)
                 connection.close()
             except:
                 logger.error(traceback.format_exc())
@@ -6608,7 +6819,8 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
                     logger.info('get_ionosphere_performance - determined start_timestamp - %s' % str(start_timestamp))
                     begin_date = datetime.datetime.utcfromtimestamp(start_timestamp).strftime('%Y-%m-%d')
                     logger.info('get_ionosphere_performance - determined begin_date - %s' % str(begin_date))
-                    request_key = '%s.%s.%s.%s.%s' % (metric, begin_date, end_date, frequency, format)
+                    request_key = '%s.%s.%s.%s' % (metric, begin_date, end_date, frequency)
+                    logger.info('get_ionosphere_performance - metric query, determine_start_timestamp cache key being generated from request key - %s' % request_key)
                 except:
                     trace = traceback.format_exc()
                     logger.error(trace)
@@ -6624,6 +6836,7 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         if not metric_ids and not metric_id:
             if engine:
                 engine_disposal(engine)
+            logger.info('get_ionosphere_performance - no metric_id or metric_ids, nothing to do')
             performance = {
                 'performance': {'date': None, 'reason': 'no metric data found'},
                 'request_key': request_key,
@@ -6633,6 +6846,9 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
                 'csv': None,
             }
             return performance
+
+    logger.info('get_ionosphere_performance - metric_id: %s, metric_ids length: %s' % (
+        str(metric_id), str(len(metric_ids))))
 
     # Create request_key performance directory
     ionosphere_dir = path.dirname(settings.IONOSPHERE_DATA_FOLDER)
@@ -6662,27 +6878,36 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         try:
             connection = engine.connect()
             if metric_ids:
-                stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp], anomalies_table.c.metric_id.in_(metric_ids)).\
+                # stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp], anomalies_table.c.metric_id.in_(metric_ids)).\
+                stmt = select([anomalies_table.c.id, anomalies_table.c.metric_id, anomalies_table.c.anomaly_timestamp]).\
                     where(anomalies_table.c.anomaly_timestamp >= start_timestamp).\
                     where(anomalies_table.c.anomaly_timestamp <= end_timestamp)
                 result = connection.execute(stmt)
             elif metric_id:
-                stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp]).\
+                stmt = select([anomalies_table.c.id, anomalies_table.c.metric_id, anomalies_table.c.anomaly_timestamp]).\
                     where(anomalies_table.c.metric_id == int(metric_id)).\
                     where(anomalies_table.c.anomaly_timestamp >= start_timestamp).\
                     where(anomalies_table.c.anomaly_timestamp <= end_timestamp)
                 result = connection.execute(stmt)
             else:
-                stmt = select([anomalies_table.c.id, anomalies_table.c.anomaly_timestamp]).\
+                stmt = select([anomalies_table.c.id, anomalies_table.c.metric_id, anomalies_table.c.anomaly_timestamp]).\
                     where(anomalies_table.c.anomaly_timestamp >= start_timestamp).\
                     where(anomalies_table.c.anomaly_timestamp <= end_timestamp)
                 result = connection.execute(stmt)
             for row in result:
-                anomaly_id = row['id']
-                anomaly_timestamp = row['anomaly_timestamp']
-                anomalies.append(int(anomaly_timestamp))
-                # anomalies_ts.append([datetime.datetime.fromtimestamp(int(anomaly_timestamp)), int(anomaly_id)])
-                anomalies_ts.append([int(anomaly_timestamp), int(anomaly_id)])
+                r_metric_id = row['metric_id']
+                append_result = False
+                if r_metric_id == metric_id:
+                    append_result = True
+                if not append_result:
+                    if r_metric_id in metric_ids:
+                        append_result = True
+                if append_result:
+                    anomaly_id = row['id']
+                    anomaly_timestamp = row['anomaly_timestamp']
+                    anomalies.append(int(anomaly_timestamp))
+                    # anomalies_ts.append([datetime.datetime.fromtimestamp(int(anomaly_timestamp)), int(anomaly_id)])
+                    anomalies_ts.append([int(anomaly_timestamp), int(anomaly_id)])
             connection.close()
         except:
             logger.error(traceback.format_exc())
@@ -6699,84 +6924,171 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
     # Get fp_ids
     fp_ids = []
     fp_ids_ts = []
+
+    fp_ids_cache_key = 'performance.%s.%s.fp_ids' % (request_key, timezone_str)
+    fp_ids_ts_cache_key = 'performance.%s.%s.fp_ids_ts' % (request_key, timezone_str)
+
+    if not redis_conn_decoded:
+        try:
+            redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: get_ionosphere_performance :: get_redis_conn_decoded failed')
     try:
-        ionosphere_table, log_msg, trace = ionosphere_table_meta(skyline_app, engine)
-        logger.info(log_msg)
+        fp_ids_raw = redis_conn_decoded.get(fp_ids_cache_key)
     except:
-        logger.error(traceback.format_exc())
-        logger.error('error :: get_ionosphere_performance - failed to get ionosphere_table meta')
-        if engine:
-            engine_disposal(engine)
-        raise  # to webapp to return in the UI
+        trace = traceback.format_exc()
+        fail_msg = 'error :: get_ionosphere_performance - could not get Redis data for - %s' % fp_ids_cache_key
+        logger.error(trace)
+        logger.error(fail_msg)
+    if fp_ids_raw:
+        try:
+            fp_ids = literal_eval(fp_ids_raw)
+        except:
+            trace = traceback.format_exc()
+            fail_msg = 'error :: get_ionosphere_performance - could not get literal_eval Redis data from key - %s' % fp_ids_cache_key
+            logger.error(trace)
+            logger.error(fail_msg)
+    if fp_ids:
+        logger.info('get_ionosphere_performance - using fp_ids from cache')
+
     try:
-        connection = engine.connect()
-        if metric_ids:
-            if fp_type == 'user':
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
-                    where(ionosphere_table.c.generation <= 1)
-            elif fp_type == 'learnt':
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
-                    where(ionosphere_table.c.generation >= 2)
-            else:
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
-            logger.info('get_ionosphere_performance - determining fp ids of type %s for metric_ids' % fp_type)
-            result = connection.execute(stmt)
-        elif metric_id:
-            if fp_type == 'user':
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
-                    where(ionosphere_table.c.metric_id == int(metric_id)).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
-                    where(ionosphere_table.c.generation <= 1)
-            elif fp_type == 'learnt':
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
-                    where(ionosphere_table.c.metric_id == int(metric_id)).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
-                    where(ionosphere_table.c.generation >= 2)
-            else:
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
-                    where(ionosphere_table.c.metric_id == int(metric_id)).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
-            logger.info('get_ionosphere_performance - determining fp ids for metric_id')
-            result = connection.execute(stmt)
-        else:
-            if fp_type == 'user':
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
-                    where(ionosphere_table.c.generation <= 1)
-            elif fp_type == 'learnt':
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
-                    where(ionosphere_table.c.generation >= 2)
-            else:
-                stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp]).\
-                    where(ionosphere_table.c.enabled == 1).\
-                    where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
-            logger.info('get_ionosphere_performance - determining fp ids for all metrics')
-            result = connection.execute(stmt)
-        for row in result:
-            fp_id = row['id']
-            anomaly_timestamp = row['anomaly_timestamp']
-            fp_ids.append(int(fp_id))
-            fp_ids_ts.append([int(anomaly_timestamp), int(fp_id)])
-        connection.close()
+        fp_ids_ts_raw = redis_conn_decoded.get(fp_ids_ts_cache_key)
     except:
-        logger.error(traceback.format_exc())
-        logger.error('error :: get_ionosphere_performance - could not determine fp_ids')
-        if engine:
-            engine_disposal(engine)
-        raise
-    logger.info('get_ionosphere_performance - fp_ids_ts length - %s' % str(len(fp_ids_ts)))
+        trace = traceback.format_exc()
+        fail_msg = 'error :: get_ionosphere_performance - could not get Redis data for - %s' % fp_ids_ts_cache_key
+        logger.error(trace)
+        logger.error(fail_msg)
+    if fp_ids_ts_raw:
+        try:
+            fp_ids_ts = literal_eval(fp_ids_ts_raw)
+        except:
+            trace = traceback.format_exc()
+            fail_msg = 'error :: get_ionosphere_performance - could not get literal_eval Redis data from key - %s' % fp_ids_ts_cache_key
+            logger.error(trace)
+            logger.error(fail_msg)
+    if fp_ids_ts:
+        logger.info('get_ionosphere_performance - using fp_ids_ts from cache')
+
+    if not fp_ids or not fp_ids_ts:
+        try:
+            ionosphere_table, log_msg, trace = ionosphere_table_meta(skyline_app, engine)
+            logger.info(log_msg)
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: get_ionosphere_performance - failed to get ionosphere_table meta')
+            if engine:
+                engine_disposal(engine)
+            raise  # to webapp to return in the UI
+        try:
+            logger.info('get_ionosphere_performance - determining fp ids of type %s' % fp_type)
+            connection = engine.connect()
+            if metric_ids:
+                if fp_type == 'user':
+                    # stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                        where(ionosphere_table.c.generation <= 1)
+                elif fp_type == 'learnt':
+                    # stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                        where(ionosphere_table.c.generation >= 2)
+                else:
+                    # stmt = select([ionosphere_table.c.id, ionosphere_table.c.anomaly_timestamp], ionosphere_table.c.metric_id.in_(metric_ids)).\
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
+                logger.info('get_ionosphere_performance - determining fp ids of type %s for metric_ids' % fp_type)
+                result = connection.execute(stmt)
+            elif metric_id:
+                if fp_type == 'user':
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.metric_id == int(metric_id)).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                        where(ionosphere_table.c.generation <= 1)
+                elif fp_type == 'learnt':
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.metric_id == int(metric_id)).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                        where(ionosphere_table.c.generation >= 2)
+                else:
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.metric_id == int(metric_id)).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
+                logger.info('get_ionosphere_performance - determining fp ids for metric_id')
+                result = connection.execute(stmt)
+            else:
+                if fp_type == 'user':
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                        where(ionosphere_table.c.generation <= 1)
+                elif fp_type == 'learnt':
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp).\
+                        where(ionosphere_table.c.generation >= 2)
+                else:
+                    stmt = select([ionosphere_table.c.id, ionosphere_table.c.metric_id, ionosphere_table.c.anomaly_timestamp]).\
+                        where(ionosphere_table.c.enabled == 1).\
+                        where(ionosphere_table.c.anomaly_timestamp <= end_timestamp)
+                logger.info('get_ionosphere_performance - determining fp ids for all metrics')
+                result = connection.execute(stmt)
+            for row in result:
+                r_metric_id = row['metric_id']
+                append_result = False
+                if r_metric_id == metric_id:
+                    append_result = True
+                if r_metric_id in metric_ids:
+                    append_result = True
+                if append_result:
+                    fp_id = row['id']
+                    anomaly_timestamp = row['anomaly_timestamp']
+                    fp_ids.append(int(fp_id))
+                    fp_ids_ts.append([int(anomaly_timestamp), int(fp_id)])
+            connection.close()
+        except:
+            logger.error(traceback.format_exc())
+            logger.error('error :: get_ionosphere_performance - could not determine fp_ids')
+            if engine:
+                engine_disposal(engine)
+            raise
+        logger.info('get_ionosphere_performance - fp_ids_ts length - %s' % str(len(fp_ids_ts)))
+
+        if fp_ids:
+            if not redis_conn:
+                try:
+                    redis_conn = get_redis_conn(skyline_app)
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: get_redis_conn failed for get_ionosphere_performance')
+            if redis_conn:
+                try:
+                    logger.info('get_ionosphere_performance - setting Redis performance key with fp_ids containing %s items' % str(len(fp_ids)))
+                    redis_conn.setex(fp_ids_cache_key, 600, str(fp_ids))
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: get_redis_conn failed to set - %s' % fp_ids_cache_key)
+        if fp_ids_ts:
+            if not redis_conn:
+                try:
+                    redis_conn = get_redis_conn(skyline_app)
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: get_redis_conn failed for get_ionosphere_performance')
+            if redis_conn:
+                try:
+                    logger.info('get_ionosphere_performance - setting Redis performance key with fp_ids_ts containing %s items' % str(len(fp_ids_ts)))
+                    redis_conn.setex(fp_ids_ts_cache_key, 600, str(fp_ids_ts))
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: get_redis_conn failed to set - %s' % fp_ids_ts_cache_key)
 
     # Get fp matches
     try:
@@ -6791,14 +7103,23 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
     if fp_ids:
         try:
             connection = engine.connect()
-            stmt = select([ionosphere_matched_table.c.id, ionosphere_matched_table.c.metric_timestamp], ionosphere_matched_table.c.fp_id.in_(fp_ids)).\
+            # stmt = select([ionosphere_matched_table.c.id, ionosphere_matched_table.c.metric_timestamp], ionosphere_matched_table.c.fp_id.in_(fp_ids)).\
+            stmt = select([ionosphere_matched_table.c.id, ionosphere_matched_table.c.fp_id, ionosphere_matched_table.c.metric_timestamp]).\
                 where(ionosphere_matched_table.c.metric_timestamp >= start_timestamp).\
                 where(ionosphere_matched_table.c.metric_timestamp <= end_timestamp)
             result = connection.execute(stmt)
             for row in result:
-                matched_id = row['id']
-                metric_timestamp = row['metric_timestamp']
-                fps_matched_ts.append([int(metric_timestamp), int(matched_id)])
+                append_result = False
+                if metric == 'all' and metric_like == 'all':
+                    append_result = True
+                if not append_result:
+                    fp_id = row['fp_id']
+                    if fp_id in fp_ids:
+                        append_result = True
+                if append_result:
+                    matched_id = row['id']
+                    metric_timestamp = row['metric_timestamp']
+                    fps_matched_ts.append([int(metric_timestamp), int(matched_id)])
             connection.close()
         except:
             logger.error(traceback.format_exc())
@@ -6823,14 +7144,23 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
     if fp_ids:
         try:
             connection = engine.connect()
-            stmt = select([ionosphere_layers_matched_table.c.id, ionosphere_layers_matched_table.c.anomaly_timestamp], ionosphere_layers_matched_table.c.fp_id.in_(fp_ids)).\
+            # stmt = select([ionosphere_layers_matched_table.c.id, ionosphere_layers_matched_table.c.anomaly_timestamp], ionosphere_layers_matched_table.c.fp_id.in_(fp_ids)).\
+            stmt = select([ionosphere_layers_matched_table.c.id, ionosphere_layers_matched_table.c.fp_id, ionosphere_layers_matched_table.c.anomaly_timestamp]).\
                 where(ionosphere_layers_matched_table.c.anomaly_timestamp >= start_timestamp).\
                 where(ionosphere_layers_matched_table.c.anomaly_timestamp <= end_timestamp)
             result = connection.execute(stmt)
             for row in result:
-                matched_layers_id = row['id']
-                matched_timestamp = row['anomaly_timestamp']
-                layers_matched_ts.append([int(matched_timestamp), int(matched_layers_id)])
+                append_result = False
+                if metric == 'all' and metric_like == 'all':
+                    append_result = True
+                if not append_result:
+                    fp_id = row['fp_id']
+                    if fp_id in fp_ids:
+                        append_result = True
+                if append_result:
+                    matched_layers_id = row['id']
+                    matched_timestamp = row['anomaly_timestamp']
+                    layers_matched_ts.append([int(matched_timestamp), int(matched_layers_id)])
             connection.close()
         except:
             trace = traceback.format_exc()
@@ -6847,6 +7177,11 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         try:
             anomalies_df = pd.DataFrame(anomalies_ts, columns=['date', 'id'])
             anomalies_df['date'] = pd.to_datetime(anomalies_df['date'], unit='s')
+            # @added 20210202 - Feature #3934: ionosphere_performance
+            # Handle user timezone
+            if timezone_str != 'UTC':
+                anomalies_df['date'] = anomalies_df['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+
             anomalies_df = anomalies_df.set_index(pd.DatetimeIndex(anomalies_df['date']))
             anomalies_df = anomalies_df.resample(frequency).apply({'id': 'count'})
             anomalies_df.rename(columns={'id': 'anomaly_count'}, inplace=True)
@@ -6867,6 +7202,11 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         try:
             fp_ids_df = pd.DataFrame(fp_ids_ts, columns=['date', 'id'])
             fp_ids_df['date'] = pd.to_datetime(fp_ids_df['date'], unit='s')
+            # @added 20210202 - Feature #3934: ionosphere_performance
+            # Handle user timezone
+            if timezone_str != 'UTC':
+                fp_ids_df['date'] = fp_ids_df['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+
             fp_ids_df = fp_ids_df.set_index(pd.DatetimeIndex(fp_ids_df['date']))
             fp_ids_df = fp_ids_df.resample(frequency).apply({'id': 'count'})
             fps_total_df = fp_ids_df.cumsum()
@@ -6890,6 +7230,11 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         try:
             fps_matched_df = pd.DataFrame(fps_matched_ts, columns=['date', 'id'])
             fps_matched_df['date'] = pd.to_datetime(fps_matched_df['date'], unit='s')
+            # @added 20210202 - Feature #3934: ionosphere_performance
+            # Handle user timezone
+            if timezone_str != 'UTC':
+                fps_matched_df['date'] = fps_matched_df['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+
             fps_matched_df = fps_matched_df.set_index(pd.DatetimeIndex(fps_matched_df['date']))
             fps_matched_df = fps_matched_df.resample(frequency).apply({'id': 'count'})
             fps_matched_df.rename(columns={'id': 'fps_matched_count'}, inplace=True)
@@ -6909,6 +7254,11 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         try:
             layers_matched_df = pd.DataFrame(layers_matched_ts, columns=['date', 'id'])
             layers_matched_df['date'] = pd.to_datetime(layers_matched_df['date'], unit='s')
+            # @added 20210202 - Feature #3934: ionosphere_performance
+            # Handle user timezone
+            if timezone_str != 'UTC':
+                layers_matched_df['date'] = layers_matched_df['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+
             layers_matched_df = layers_matched_df.set_index(pd.DatetimeIndex(layers_matched_df['date']))
             layers_matched_df = layers_matched_df.resample(frequency).apply({'id': 'count'})
             layers_matched_df.rename(columns={'id': 'layers_matched_count'}, inplace=True)
@@ -6926,8 +7276,24 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
 
     date_list = pd.date_range(begin_date, end_date, freq=frequency)
     date_list = date_list.format(formatter=lambda x: x.strftime('%Y-%m-%d'))
+    use_end_date = end_date
+    if not date_list:
+        date_list = pd.date_range(begin_date, extended_end_date, freq=frequency)
+        date_list = date_list.format(formatter=lambda x: x.strftime('%Y-%m-%d'))
+        use_end_date = extended_end_date
+    # logger.debug('debug :: get_ionosphere_performance - date_list - %s' % str(date_list))
+
     # performance_df = pd.DataFrame(date_list, columns=['date'])
-    performance_df = pd.DataFrame({'date': pd.date_range(begin_date, end_date, freq=frequency), 'day': date_list})
+    performance_df = pd.DataFrame({'date': pd.date_range(begin_date, use_end_date, freq=frequency), 'day': date_list})
+    # @added 20210202 - Feature #3934: ionosphere_performance
+    # Handle user timezone
+    if timezone_str != 'UTC':
+        # It is already timezone aware in the begin_date and end_date, so I one
+        # just reassign the same tzinfo to the date index?
+        # Fuck yeah!!! (I sound like Colt Bennet)
+        # performance_df['date'] = performance_df['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+        performance_df['date'] = performance_df['date'].dt.tz_localize(user_timezone).dt.tz_convert(user_timezone)
+
     # performance_df = performance_df.set_index(pd.DatetimeIndex(performance_df['date']))
     performance_df = performance_df.set_index(['date'])
 
@@ -6946,20 +7312,29 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
             report_new_fps = True
 
     if len(fp_ids_df) > 0 and report_new_fps:
-        performance_df = pd.merge(performance_df, fp_ids_df, how='outer', on='date')
+        if yesterday_data:
+            new_fp_ids_df = fp_ids_df.loc[yesterday_end_date:use_end_date]
+            performance_df = pd.merge(performance_df, new_fp_ids_df, how='outer', on='date')
+            del new_fp_ids_df
+        else:
+            performance_df = pd.merge(performance_df, fp_ids_df, how='outer', on='date')
         performance_df.sort_values('date')
         performance_df['new_fps_count'] = performance_df['new_fps_count'].fillna(0)
-    else:
-        performance_df['new_fps_count'] = 0
+    # else:
+    #    performance_df['new_fps_count'] = 0
 
-    # Report new fp count per day
+    # Report running total fp count per day
     report_total_fps = False
     if 'total_fps' in request.args:
         total_fps_str = request.args.get('total_fps', 'false')
         if total_fps_str == 'true':
             report_total_fps = True
     if len(fps_total_df) > 0 and report_total_fps:
-        performance_df = pd.merge(performance_df, fps_total_df, how='outer', on='date')
+        if yesterday_data:
+            new_fps_total = fps_total_df.loc[yesterday_end_date:use_end_date]
+            performance_df = pd.merge(performance_df, new_fps_total, how='outer', on='date')
+        else:
+            performance_df = pd.merge(performance_df, fps_total_df, how='outer', on='date')
         performance_df.sort_values('date')
         performance_df['fps_total_count'].fillna(method='ffill', inplace=True)
         logger.info('get_ionosphere_performance - second step of creating performance_df complete, dataframe length - %s' % str(len(performance_df)))
@@ -7003,7 +7378,10 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
 
     if report_sum_matches:
         logger.info('get_ionosphere_performance - creating matches_sum_df to calculate totals and merge with performance_df')
-        matches_sum_df = pd.DataFrame({'date': pd.date_range(begin_date, end_date, freq=frequency), 'day': date_list})
+        matches_sum_df = pd.DataFrame({'date': pd.date_range(begin_date, use_end_date, freq=frequency), 'day': date_list})
+        if timezone_str != 'UTC':
+            matches_sum_df['date'] = matches_sum_df['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+
         matches_sum_df = matches_sum_df.set_index(['date'])
         if len(fps_matched_df) > 0:
             matches_sum_df = pd.merge(matches_sum_df, fps_matched_df, how='outer', on='date')
@@ -7024,66 +7402,104 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         performance_df.sort_values('date')
         performance_df['total_matches'] = performance_df['total_matches'].fillna(0)
 
+    if yesterday_data:
+        ydf = pd.DataFrame(yesterday_data)
+        ydf = ydf.transpose()
+
+        # ydf['day'] = pd.to_datetime(ydf['day'], format='%Y-%m-%d')
+        # ydf['day'] = ydf['day'].astype('datetime64')
+        # ydf['date'] = ydf['day']
+        # ydf = ydf.set_index(['date'])
+
+        ydf['date'] = ydf['day']
+        ydf['date'] = pd.to_datetime(ydf['date'], format='%Y-%m-%d')
+        ydf['date'] = ydf['date'].astype('datetime64')
+        # @added 20210202 - Feature #3934: ionosphere_performance
+        # Handle user timezone
+        if timezone_str != 'UTC':
+            ydf['date'] = ydf['date'].dt.tz_localize('UTC').dt.tz_convert(user_timezone)
+
+        ydf = ydf.set_index(['date'])
+
+        logger.info('get_ionosphere_performance - yesterday_data dataframe has %s rows' % str(len(ydf)))
+        logger.info('get_ionosphere_performance - performance_df dataframe has %s rows before merge' % str(len(performance_df)))
+        # df_merged = reduce(lambda left, right: pd.merge(left, right, on=['date'], how='outer'), [ydf, performance_df])
+        # df_merged = pd.merge(ydf, performance_df, on='day', how='outer')
+        df_merged = pd.concat([ydf, performance_df])
+        performance_df = df_merged
+        logger.info('get_ionosphere_performance - performance_df dataframe has %s rows after merge' % str(len(performance_df)))
+
     if len(performance_df) > 0:
         logger.info('get_ionosphere_performance - final step of creating performance_df with %s columns' % str(len(performance_df.columns)))
         logger.info('get_ionosphere_performance - columns - %s' % str(performance_df.columns))
-        # performance_df = performance_df.set_index(['date'])
-        performance_df = performance_df[(performance_df.index > begin_date) & (performance_df.index <= end_date)]
+        # performance_df = performance_df[(performance_df.index > begin_date) & (performance_df.index <= end_date)]
+        performance_df = performance_df[(performance_df.index > original_begin_date) & (performance_df.index <= use_end_date)]
+        performance_df = performance_df.dropna(how='any')
 
-    # Custom title
-    if 'title' in request.args:
-        title_str = request.args.get('title', 'default')
-        if title_str != 'default':
-            if title_str == 'none':
-                plot_title = ''
-            else:
-                plot_title = title_str
-    style = []
-    if 'anomaly_count' in performance_df.columns:
-        style.append('r')
-    if 'new_fps_count' in performance_df.columns:
-        style.append('orange')
-    if 'fps_total_count' in performance_df.columns:
-        style.append('brown')
-    if 'fps_matched_count' in performance_df.columns:
-        style.append('blue')
-    if 'layers_matched_count' in performance_df.columns:
-        style.append('deepskyblue')
-    if 'total_matches' in performance_df.columns:
-        style.append('green')
+    plot_png = None
+    if format != 'json':
+        # Custom title
+        if 'title' in request.args:
+            title_str = request.args.get('title', 'default')
+            if title_str != 'default':
+                if title_str == 'none':
+                    plot_title = ''
+                else:
+                    plot_title = title_str
+        style = []
+        if 'anomaly_count' in performance_df.columns:
+            style.append('r')
+        if 'new_fps_count' in performance_df.columns:
+            style.append('orange')
+        if 'fps_total_count' in performance_df.columns:
+            style.append('brown')
+        if 'fps_matched_count' in performance_df.columns:
+            style.append('blue')
+        if 'layers_matched_count' in performance_df.columns:
+            style.append('deepskyblue')
+        if 'total_matches' in performance_df.columns:
+            style.append('green')
 
-    # Custom title
-    if 'title' in request.args:
-        title_str = request.args.get('title', 'default')
-        if title_str != 'default':
-            if title_str == 'none':
-                plot_title = ''
-            else:
-                plot_title = title_str
+        # Custom size
+        width = 14
+        height = 7
+        if 'width' in request.args:
+            width_str = request.args.get('width', '14')
+            if width_str:
+                try:
+                    width = int(width_str)
+                except:
+                    logger.error('get_ionosphere_performance - width argument not int - %s' % str(width))
+        if 'height' in request.args:
+            height_str = request.args.get('height', '7')
+            if height_str:
+                try:
+                    height = int(height_str)
+                except:
+                    logger.error('get_ionosphere_performance - height argument not int - %s' % str(height))
 
-    # Custom size
-    width = 14
-    height = 7
-    if 'width' in request.args:
-        width_str = request.args.get('width', '14')
-        if width_str:
-            try:
-                width = int(width_str)
-            except:
-                logger.error('get_ionosphere_performance - width argument not int - %s' % str(width))
-    if 'height' in request.args:
-        height_str = request.args.get('height', '7')
-        if height_str:
-            try:
-                height = int(height_str)
-            except:
-                logger.error('get_ionosphere_performance - height argument not int - %s' % str(height))
+        plot_png = '%s/%s.png' % (performance_dir, request_key)
 
-    plot_png = '%s/%s.png' % (performance_dir, request_key)
-    fig = performance_df.plot(
-        figsize=(width, height), title=plot_title, linewidth=1,
-        style=style).get_figure()
-    fig.savefig(plot_png)
+        # @added 20210127 - Feature #3934: ionosphere_performance
+        # Added secondary axis for fps_total_count
+        plot_done = False
+        if 'fps_total_count' in performance_df.columns and report_total_fps:
+            import matplotlib.pyplot as plt
+            plt.figure()
+            ax = performance_df.plot(
+                secondary_y=['fps_total_count'],
+                figsize=(width, height), title=plot_title, linewidth=1,
+                style=style)
+            ax.set_ylabel('Total fps')
+            # ax.right_ax.set_ylabel('Anomalies, new fps and matches')
+            plt.savefig(plot_png)
+            plot_done = True
+
+        if not plot_done:
+            fig = performance_df.plot(
+                figsize=(width, height), title=plot_title, linewidth=1,
+                style=style).get_figure()
+            fig.savefig(plot_png)
 
     performance_dict = {}
     csv_file = '%s/%s.csv' % (performance_dir, request_key)
@@ -7096,6 +7512,39 @@ def get_ionosphere_performance(metric, metric_like, from_timestamp, until_timest
         new_performance_df.to_csv(csv_file, index=False)
         # performance_dict = new_performance_df.to_dict()
         performance_dict = new_performance_df.to_dict('records')
+        # logger.debug('get_ionosphere_performance - performance_dict: %s' % str(performance_dict))
+
+    yesterday_data_dict = {}
+    yesterday_date_time_obj = datetime.datetime.strptime(yesterday_end_date, '%Y-%m-%d')
+    # logger.debug('debug :: get_ionosphere_performance - performance_dict - %s' % str(performance_dict))
+    for item in performance_dict:
+        for key in item:
+            if key == 'date':
+                date_time_str = item['date']
+                date_time_obj = datetime.datetime.strptime(date_time_str, '%Y-%m-%d')
+                if date_time_obj <= yesterday_date_time_obj:
+                    yesterday_data_dict[date_time_str] = {}
+                    for a_key in item:
+                        if a_key != 'date':
+                            yesterday_data_dict[date_time_str][a_key] = item[a_key]
+                        else:
+                            yesterday_data_dict[date_time_str]['day'] = item[a_key]
+    if yesterday_data_dict:
+        if not yesterday_data:
+            if not redis_conn:
+                try:
+                    redis_conn = get_redis_conn(skyline_app)
+                except:
+                    logger.error(traceback.format_exc())
+                    logger.error('error :: get_redis_conn failed for get_ionosphere_performance')
+            if redis_conn:
+                try:
+                    logger.info('get_ionosphere_performance - setting Redis performance key with yesterday_data containing %s items' % str(len(yesterday_data_dict)))
+                    redis_conn.setex(yesterday_data_cache_key, 648000, str(yesterday_data_dict))
+                    del yesterday_data_dict
+                    del yesterday_data
+                except:
+                    pass
 
     if engine:
         engine_disposal(engine)

--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -953,7 +953,11 @@ Or if no metrics with training data are present <code>{"data":{"metrics":[]},"st
   		    <tbody>
   		      <tr>
   		        <td>Description:</td>
-  		        <td>Returns the yhat values (mean and value OPTIONAL) for a metric timeseries as a json object</td>
+  		        <td>Returns the yhat values (mean and value OPTIONAL) for a metric timeseries as a json object<br>
+              yhat values default to the upper and lower three-sigma boundaries.<br>
+              If any custom algorithms are in use the three-sigma yhat upper and lower vlues are replaced with the value (+/- 10%) which the custom algorithm did not trigger on<br>
+              Where the customa algorithm replaces the three-sigma value in the yhat_upper or yhat_lower elements, a 3sigma_lower or 3sigma_upper will also be returned in the element
+              </td>
   		      </tr>
   		      <tr>
   		        <td>Endpoint:</td>
@@ -972,6 +976,8 @@ Or if no metrics with training data are present <code>{"data":{"metrics":[]},"st
                   include_value=[false | boolean | optional defaults to false]</br>
                   include_mean=[false | boolean | optional defaults to false]</br>
                   include_yhat_real_lower=[false | boolean | optional defaults to false]</br>
+                  include_anomalous_periods=[false | boolean | optional defaults to false]</br>
+                  remove_prefix=[str | optional] - prefix string to remove (do not pass a trailing dot)</br>
               </td>
   		      </tr>
   		      <tr>

--- a/updates/sql/v2.1.0-patch-dev-3934.sql
+++ b/updates/sql/v2.1.0-patch-dev-3934.sql
@@ -1,0 +1,15 @@
+/*
+This is a development SQL script to patch Skyline the initial v2.1.0 and bring
+the DB up to date with new index definitions.
+*/
+
+USE skyline;
+
+/*
+# @added 20210201 - Feature #3934: ionosphere_performance
+*/
+ALTER TABLE `ionosphere_matched` DROP INDEX `features_profile_matched`;
+ALTER TABLE `ionosphere_matched` ADD INDEX `features_profile_matched` (`id`,`fp_id`,`metric_timestamp`);
+ALTER TABLE `ionosphere_layers_matched` DROP INDEX `layers_matched`;
+ALTER TABLE `ionosphere_layers_matched` ADD INDEX `layers_matched` (`id`,`layer_id`,`fp_id`,`metric_id`,`anomaly_timestamp`);
+INSERT INTO `sql_versions` (version) VALUES ('2.1.0-patch-dev-3934');

--- a/updates/sql/v2.1.0.sql
+++ b/updates/sql/v2.1.0.sql
@@ -56,4 +56,12 @@ ALTER TABLE `metrics` DROP INDEX `metric`;
 /* Add inactive_at AND ionosphere_enabled */
 ALTER TABLE `metrics` ADD INDEX `metric` (`id`,`metric`,`ionosphere_enabled`,`inactive`);
 
+/*
+# @added 20210201 - Feature #3934: ionosphere_performance
+*/
+ALTER TABLE `ionosphere_matched` DROP INDEX `features_profile_matched`;
+ALTER TABLE `ionosphere_matched` ADD INDEX `features_profile_matched` (`id`,`fp_id`,`metric_timestamp`);
+ALTER TABLE `ionosphere_layers_matched` DROP INDEX `layers_matched`;
+ALTER TABLE `ionosphere_layers_matched` ADD INDEX `layers_matched` (`id`,`layer_id`,`fp_id`,`metric_id`,`anomaly_timestamp`);
+
 INSERT INTO `sql_versions` (version) VALUES ('2.1.0');


### PR DESCRIPTION
… changes

IssueID #3958: Handle secondary algorithms in yhat_values
IssueID #3956: luminosity - motifs
IssueID #3934: ionosphere_performance

- Handle secondary algorithms in yhat_values and use extended_values to shift
  the yhat values if the secondary algorithm does not trigger in webapp and
  webapp/backend. And added anomalous_periods_dict and include_anomalous_periods
  to get_yhat_values (3958)
- Improve performance on get_ionosphere_performance with caching and add
  additional timestamp columns to ionosphere_matched and ionosphere_layers_matched
  tables.  Handle user timezones (3934)
- Improve luminosity_remote_data performance, although the is_derivative_metric
  function is appropriate it is not the most performant manner in which to
  determine if the metrics are derivatives, as it needs to fire on every metric
  so we just trust the Redis derivative_metrics list.  This increases
  performance on 1267 metrics from 6.442009 seconds to 1.473067 seconds (3956)
- Update and correct docstrings in settings related to FLUX_API_KEYS
- Added IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE and
  IONOSPHERE_PERFORMANCE_DATA_POPULATE_CACHE to settings and started adding to
  metrics_manager to populate the cache (3934)

Added:
updates/sql/v2.1.0-patch-dev-3934.sql
Modified:
docs/vista.rst
skyline/analyzer/metrics_manager.py
skyline/settings.py
skyline/skyline.sql
skyline/webapp/backend.py
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/api.html
skyline/webapp/webapp.py
updates/sql/v2.1.0.sql