### PR TITLE
Fix timezone issue in ionosphere_performance

### DIFF
--- a/skyline/webapp/ionosphere_backend.py
+++ b/skyline/webapp/ionosphere_backend.py
@@ -6696,13 +6696,13 @@ def get_ionosphere_performance(
                 # @added 20210203 - Feature #3934: ionosphere_performance
                 # Handle user timezone
                 if timezone_str != 'UTC':
-                    logger.info('get_ionosphere_performance - determining %s datetime from UTC start_timestamp - %s' % (timezone_str, str(start_timestamp)))
-                    from_timestamp_datetime_obj = datetime.datetime.strptime(start_timestamp, '%Y-%m-%d %H:%M:%S')
+                    logger.info('get_ionosphere_performance - determining %s datetime from UTC start_timestamp_str - %s' % (timezone_str, str(start_timestamp_str)))
+                    from_timestamp_datetime_obj = datetime.datetime.strptime(start_timestamp_str, '%Y-%m-%d %H:%M:%S')
                     logger.info('get_ionosphere_performance - from_timestamp_datetime_obj - %s' % str(from_timestamp_datetime_obj))
                     tz_offset = pytz.timezone(timezone_str).localize(from_timestamp_datetime_obj).strftime('%z')
-                    tz_from_date = '%s %s' % (from_timestamp, tz_offset)
+                    tz_from_date = '%s %s' % (start_timestamp_str, tz_offset)
                     logger.info('get_ionosphere_performance - tz_from_date - %s' % str(tz_from_date))
-                    tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y%m%d %H:%M:%S %z')
+                    tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y-%m-%d %H:%M:%S %z')
                     begin_date = tz_from_timestamp_datetime_obj.strftime('%Y-%m-%d')
                     logger.info('get_ionosphere_performance - begin_date with %s timezone applied - %s' % (timezone_str, str(begin_date)))
 
@@ -6745,13 +6745,13 @@ def get_ionosphere_performance(
                     # @added 20210203 - Feature #3934: ionosphere_performance
                     # Handle user timezone
                     if timezone_str != 'UTC':
-                        logger.info('get_ionosphere_performance - determining %s datetime from UTC start_timestamp - %s' % (timezone_str, str(start_timestamp)))
-                        from_timestamp_datetime_obj = datetime.datetime.strptime(start_timestamp, '%Y-%m-%d %H:%M:%S')
+                        logger.info('get_ionosphere_performance - determining %s datetime from UTC start_timestamp_str - %s' % (timezone_str, str(start_timestamp_str)))
+                        from_timestamp_datetime_obj = datetime.datetime.strptime(start_timestamp_str, '%Y-%m-%d %H:%M:%S')
                         logger.info('get_ionosphere_performance - from_timestamp_datetime_obj - %s' % str(from_timestamp_datetime_obj))
                         tz_offset = pytz.timezone(timezone_str).localize(from_timestamp_datetime_obj).strftime('%z')
-                        tz_from_date = '%s %s' % (from_timestamp, tz_offset)
+                        tz_from_date = '%s %s' % (start_timestamp_str, tz_offset)
                         logger.info('get_ionosphere_performance - tz_from_date - %s' % str(tz_from_date))
-                        tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y%m%d %H:%M:%S %z')
+                        tz_from_timestamp_datetime_obj = datetime.datetime.strptime(tz_from_date, '%Y-%m-%d %H:%M:%S %z')
                         begin_date = tz_from_timestamp_datetime_obj.strftime('%Y-%m-%d')
                         logger.info('get_ionosphere_performance - begin_date with %s timezone applied - %s' % (timezone_str, str(begin_date)))
 

--- a/skyline/webapp/templates/ionosphere_performance.html
+++ b/skyline/webapp/templates/ionosphere_performance.html
@@ -70,6 +70,10 @@
   		        <td><input type="text" name="metric" value="all" /> Metric name (if one is desired)</td>
   		      </tr>
   		      <tr>
+  		        <td>remove prefix:</td>
+  		        <td><input type="text" name="remove_prefix" value="false" /> Remove the prefix from the metric name (do not include the final dot) e.g. <code>telegraf</code></td>
+  		      </tr>
+  		      <tr>
   		        <td>Metric like</td>
   		        <td><input type="text" name="metric_like" value="all"> (wildcards are MySQL LIKE style, % e.g. stats.app.requests.http_status_codes.% or %.http_status_codes.%)</td>
   		      </tr>
@@ -89,6 +93,16 @@
                 <option value="monthly">monthly</option>
               </select> Period</td>
   		      </tr>
+  		      <tr>
+  		        <td>timezone</td>
+              <td><select name="tz">
+                <option value="UTC">UTC</option>
+                {% for item in pytz_timezones %}
+                <option value="{{ item }}">{{ item }}</option>
+                {% endfor %}
+              </select></td>
+  		      </tr>
+
   		      <tr>
   		        <td>anomalies</td>
               <td><select name="anomalies">


### PR DESCRIPTION
IssueID #3934: ionosphere_performance

- Use the datetime string not the unix timestamp
- Add timezone parameter to post

Modified:
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/ionosphere_performance.html