### PR TITLE
webapp - last_analyzed_timestamp API endpoint

### DIFF
--- a/skyline/flux/listen.py
+++ b/skyline/flux/listen.py
@@ -316,7 +316,7 @@ class MetricData(object):
                     # @modified 20200206 - Feature #3444: Allow flux to backfill
                     # Only valid_timestamp is this is not a backfill request
                     if not backfill:
-                        valid_timestamp = validate_timestamp('listen :: MetricData GET', str(request_param_value))
+                        valid_timestamp = validate_timestamp('listen :: MetricData GET - parameter - %s', str(request_param_value))
                     else:
                         valid_timestamp = True
                     if valid_timestamp:
@@ -718,7 +718,7 @@ class MetricDataPost(object):
                     # @modified 20200206 - Feature #3444: Allow flux to backfill
                     # Only valid_timestamp is this is not a backfill request
                     if not backfill:
-                        valid_timestamp = validate_timestamp('listen :: MetricDataPOST POST', str(postData['timestamp']))
+                        valid_timestamp = validate_timestamp('listen :: MetricDataPOST POST - timestamp - %s', str(postData['timestamp']))
                     else:
                         valid_timestamp = True
                     if valid_timestamp:

--- a/skyline/webapp/ionosphere_backend.py
+++ b/skyline/webapp/ionosphere_backend.py
@@ -6485,10 +6485,18 @@ def get_ionosphere_performance(
         # @added 20210203 - Feature #3934: ionosphere_performance
         # Add default timestamp
         else:
-            start_timestamp = int(from_timestamp)
+            if from_timestamp == 'all':
+                start_timestamp = 0
+                determine_start_timestamp = True
+            else:
+                start_timestamp = int(from_timestamp)
         if from_timestamp == 'all':
             start_timestamp = 0
             determine_start_timestamp = True
+    if from_timestamp == 'all':
+        start_timestamp = 0
+        determine_start_timestamp = True
+
     if until_timestamp and until_timestamp != 'all':
         if ":" in until_timestamp:
             if timezone_str == 'UTC':
@@ -6506,7 +6514,10 @@ def get_ionosphere_performance(
         # @added 20210203 - Feature #3934: ionosphere_performance
         # Add default timestamp
         else:
-            end_timestamp = int(until_timestamp)
+            if until_timestamp == 'all':
+                end_timestamp = int(time.time())
+            else:
+                end_timestamp = int(until_timestamp)
 
     determine_timezone_end_date = False
     if until_timestamp == 'all':

--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -744,6 +744,51 @@ Or if no metrics if no metrics are Ionosphere enabled metrics <code>{"data":{"me
 		    </tbody>
 		  </table>
 
+	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/api?last_analyzed_timestamp</span></span></h4>
+  		  <table class="table table-hover">
+  		    <thead>
+  		      <tr>
+  		        <th>Name</th>
+  		        <th>Description</th>
+  		      </tr>
+  		    </thead>
+  		    <tbody>
+  		      <tr>
+  		        <td>Description:</td>
+  		        <td>Returns the last timestamp that Analyzer analysed for a metric.</br>
+                  If a timestamp for the metric does not exist the request is responded to with HTTP status code <code>400</code>
+              </td>
+  		      </tr>
+  		      <tr>
+  		        <td>Endpoint:</td>
+  		        <td><a target='_blank' href="/api?last_analyzed_timestamp">/api?last_analyzed_timestamp</a></td>
+  		      </tr>
+  		      <tr>
+  		        <td>Method:</td>
+  		        <td>GET</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Parameters:</td>
+  		        <td>metric=[metric_name | str | <font color=red>required</font>]</br>
+              </td>
+  		      </tr>
+  		      <tr>
+  		        <td>Request example:</td>
+		          <td><code>/api?last_analyzed_timestamp&metric=stats.statsd.graphiteStats.calculationtime</code></br>
+		          <td><code>/api?last_analyzed_timestamp&metric=stats.statsd.graphiteStats.calculationtime&cluster_data=true</code> [optional for clustered Skyline]
+              </td>
+  		      </tr>
+  		      <tr>
+  		        <td>Response:</td>
+  		        <td>200 - json response, example
+                  <code>
+{"data":{"last_analyzed_timestamp":1613564520,"metric":"stats.statsd.graphiteStats.calculationtime"},"status":{"cluster_data":true,"remote_data":false,"request_time":0.001747,"response":200}}
+</code><br>
+              </td>
+  		      </tr>
+		    </tbody>
+		  </table>
+
 	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/api?mirage_metrics</span></span></h4>
   		  <table class="table table-hover">
   		    <thead>


### PR DESCRIPTION
IssueID #3968: webapp - last_analyzed_timestamp API endpoint
IssueID #1448: Crucible web UI
IssueID #3934: ionosphere_performance

- Add an API endpoint to the webapp that returns the last_analyzed_timestamp for
  a metric from the analyzer.metrics.last_analyzed_timestamp or the
  analyzer.low_priority_metrics.last_analyzed_timestamp Redis hash keys.
- Added crucible_jobs_dir to IONOSPHERE_IMAGE_ALLOWED_PATHS
- Correct flux validate_timestamp caller parameter
- Set default start_timestamp and end_timestamp in for ionosphere_performance

Modified:
skyline/flux/listen.py
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/api.html
skyline/webapp/webapp.py