### PR TITLE
Update Pillow and aiohttp

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -283,7 +283,10 @@ pyparsing==2.4.7
 # https://github.com/python-pillow/Pillow/pull/5174 which fixes CVE-2020-35653
 # and CVE-2020-35655
 # When matplotlib requires >=8.1.0 this Pillow==8.1.0 can be removed
-Pillow==8.1.0
+# @modified 20210305 - Support #3972: SNYK-PYTHON-PILLOW-1080635
+# When matplotlib requires >=8.1.1 this Pillow==8.1.1 can be removed
+#Pillow==8.1.0
+Pillow==8.1.1
 
 # @modified 20160820 - Issue #23 Test dependency updates
 #matplotlib==1.5.1
@@ -626,6 +629,11 @@ git+git://github.com/earthgecko/luminol@2de3fb2#egg=luminol
 # @modified 20201229 - Task #3898: Test Python 3.8.6 and deps
 #slackclient==2.7.2
 slackclient==2.9.3
+
+# @added 20210305 - Support #3974: SNYK-PYTHON-AIOHTTP-1079232
+# Open Redirect in aiohttp@3.7.3 introduced by slackclient@2.9.3 > aiohttp@3.7.3
+# When slackclient requires aiohttp>=3.7.4 this can be removed
+aiohttp==3.7.4
 
 # @added 20190412 - Task #2926: Update dependencies
 # Added to address CVE-2018-20060 as is required by requests at >=1.21.1,<1.25

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ python-dateutil==2.8.1
 pytz==2020.5
 cycler==0.10.0
 pyparsing==2.4.7
-Pillow==8.1.0
+Pillow==8.1.1
 matplotlib==3.3.3
 pandas==1.2.0
 patsy==0.5.1
@@ -48,6 +48,10 @@ SQLAlchemy==1.3.22
 pymemcache==3.4.0
 PyJWT==1.7.1
 git+git://github.com/earthgecko/luminol@2de3fb2#egg=luminol
+# @added 20210305 - Support #3974: SNYK-PYTHON-AIOHTTP-1079232
+# Open Redirect in aiohttp@3.7.3 introduced by slackclient@2.9.3 > aiohttp@3.7.3
+# When slackclient requires aiohttp>=3.7.4 this can be removed
+aiohttp==3.7.4
 slackclient==2.9.3
 urllib3==1.26.2
 graphyte==1.6.0


### PR DESCRIPTION
IssueID #3972: SNYK-PYTHON-PILLOW-1080635
IssueID #3974: SNYK-PYTHON-AIOHTTP-1079232

- Update to Pillow 8.1.1 as per:
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1080635
  CVE-2021-25293 - https://github.com/python-pillow/Pillow/commit/4853e522bddbec66022c0915b9a56255d0188bf9
  CVE-2021-25291 - https://github.com/python-pillow/Pillow/commit/8b8076bdcb3815be0ef0d279651d8d1342b8ea61
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1080654
  CVE-2021-25292 - https://github.com/python-pillow/Pillow/commit/3bce145966374dd39ce58a6fc0083f8d1890719c
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1081494 (CVE-2021-27921)
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1081501 (CVE-2021-27923)
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1081502 (CVE-2021-27922)
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1082329 (CVE-2021-25289)
  https://snyk.io/vuln/SNYK-PYTHON-PILLOW-1082750 (CVE-2021-25290)
- Update aiohttp to 3.7.4 as per:
  https://snyk.io/vuln/SNYK-PYTHON-AIOHTTP-1079232 (CVE-2021-21330)
  https://github.com/aio-libs/aiohttp/commit/2545222a3853e31ace15d87ae0e2effb7da0c96b
  https://github.com/aio-libs/aiohttp/commit/5d19ea5e28ae9a55ef1f33ea820f813bf26a7e57

Modified:
dev-requirements.txt
requirements.txt