### PR TITLE
anomaly classifications

### DIFF
--- a/skyline/skyline.sql
+++ b/skyline/skyline.sql
@@ -588,7 +588,6 @@ CREATE TABLE IF NOT EXISTS `anomalies_type` (
   `id` INT(11) NOT NULL COMMENT 'anomaly id',
   `metric_id` INT(11) NOT NULL COMMENT 'metric id',
   `type` VARCHAR(255) NOT NULL COMMENT 'a csv list of the anomaly_types ids e.g 1,2,3',
-  PRIMARY KEY (id),
   INDEX `anomalies_type_id` (`id`,`metric_id`)) ENGINE=InnoDB;
 
 /*

--- a/updates/sql/v2.1.0-patch-dev-3978-3642.sql
+++ b/updates/sql/v2.1.0-patch-dev-3978-3642.sql
@@ -27,6 +27,5 @@ CREATE TABLE IF NOT EXISTS `anomalies_type` (
   `id` INT(11) NOT NULL COMMENT 'anomaly id',
   `metric_id` INT(11) NOT NULL COMMENT 'metric id',
   `type` VARCHAR(255) NOT NULL COMMENT 'a csv list of the anomaly_types ids e.g 1,2,3',
-  PRIMARY KEY (id),
   INDEX `anomalies_type_id` (`id`,`metric_id`)) ENGINE=InnoDB;
 INSERT INTO `sql_versions` (version) VALUES ('2.1.0-patch-dev-3978-3642');


### PR DESCRIPTION
IssueID #3642: Anomaly type classification

- Remove id as PRIMARY_KEY from anomalies_type table

Modified:
skyline/skyline.sql
updates/sql/v2.1.0-patch-dev-3978-3642.sql