### PR TITLE
Add additional info about seed_data and carbon-relay #419

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -461,6 +461,12 @@ Starting and testing the Skyline installation
 
 .. code-block:: bash
 
+    # NOTE: if Graphite carbon-relay is ALREADY sending data to Horizon, seed_data
+    #       will most likely fail as Horizon/listen will already have a connection
+    #       and will be reading the Graphite pickle.  If you wish to test seeding
+    #       data, stop Graphite carbon-relay and restart Horizon, BEFORE running
+    #       seed_data.py.  Run seed_data.py and then restart Horizon and start
+    #       Graphite carbon-relay again after seed data has run.
     cd "${PYTHON_VIRTUALENV_DIR}/projects/${PROJECT}"
     source bin/activate
     "bin/python${PYTHON_MAJOR_VERSION}" /opt/skyline/github/skyline/utils/seed_data.py

--- a/utils/dawn/skyline.dawn.sh
+++ b/utils/dawn/skyline.dawn.sh
@@ -14,6 +14,7 @@
 # @modified 20200703 - Task #3608: Update Skyline to Python 3.8.3 and deps
 #                      Branch #3262: py3
 # @modified 20201016 - Branch #3068: SNAB
+# @modified 20210328 - [Q] The "horizon.test.pickle" test is getting an error. #419
 # @modified
 # @license
 # @source https://github.com/earthgecko/skyline/utils/dawn/skyline.dawn.sh
@@ -1087,6 +1088,18 @@ else
   systemctl restart apache2
 fi
 
+# @modified 20210328 - [Q] The "horizon.test.pickle" test is getting an error. #419
+# Moved to before Graphite install if it is done so that carbon-relay does not
+# block the seed_data socket connection
+echo "Seeding Skyline with data"
+sleep 2
+cd "${PYTHON_VIRTUALENV_DIR}/projects/${PROJECT}" || exit 1
+source bin/activate
+bin/python${PYTHON_MAJOR_VERSION} /opt/skyline/github/skyline/utils/seed_data.py
+deactivate
+cd /tmp || exit
+
+
 # @added 20191016 - Branch #3262: py3
 # Allow to install Graphite on CentOS 6 for now, allows for an end to end
 # testing environment
@@ -1382,14 +1395,6 @@ WantedBy = multi-user.target" > /etc/systemd/system/graphite.service
   ps aux | grep -v grep | grep skyline
   deactivate
 fi
-
-echo "Seeding Skyline with data"
-sleep 2
-cd "${PYTHON_VIRTUALENV_DIR}/projects/${PROJECT}" || exit 1
-source bin/activate
-bin/python${PYTHON_MAJOR_VERSION} /opt/skyline/github/skyline/utils/seed_data.py
-deactivate
-cd /tmp || exit
 
 echo "Skyline is deployed and running"
 echo "Please visit https://$YOUR_SKYLINE_SERVER_FQDN"

--- a/utils/seed_data.py
+++ b/utils/seed_data.py
@@ -393,6 +393,12 @@ def seed():
         print('info :: please check your settings.py and ensure that the Horizon and Redis settings are correct.')
         print('info :: ensure Redis is available via socket in your redis.conf')
         print('info :: restart these services and try again')
+        # @added 20210328 - [Q] The "horizon.test.pickle" test is getting an error. #419
+        print('WARNING :: If Graphite started and pickling data to Horizon seeding data')
+        print('WARNING :: will not work as Horizon/listen will already have a connection')
+        print('WARNING :: and will be reading the Graphite pickle.  If you wish to test')
+        print('WARNING :: seeding data, stop Graphite carbon-relay, run seed_data.py')
+        print('WARNING :: and then restart Graphite carbon-relay.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
[Q] The "horizon.test.pickle" test is getting an error. #419

- Add additional output and info informing the user that seed_data will most
  likely fail if carbon-relay is already pickling to Horizon
- Move seed_data.py run to before Graphite install.

Modified:
docs/installation.rst
utils/dawn/skyline.dawn.sh
utils/seed_data.py