### PR TITLE
flux - aggregator.py and FLUX_AGGREGATE_NAMESPACES

### DIFF
--- a/docs/flux.rst
+++ b/docs/flux.rst
@@ -34,22 +34,22 @@ For example if you sent the following 3 data points to flux for a metric:
 
   {
   	"metric": "test.multiple_timestamps_per_period.3",
-  	"timestamp": "1478021701",
-  	"value": "3.0",
+  	"timestamp": 1478021701,
+  	"value": 3.0,
   	"key": "YOURown32charSkylineAPIkeySecret"
   }
 
   {
   	"metric": "test.multiple_timestamps_per_period.3",
-  	"timestamp": "1478021715",
-  	"value": "6.0",
+  	"timestamp": 1478021715,
+  	"value": 6.0,
   	"key": "YOURown32charSkylineAPIkeySecret"
   }
 
   {
   	"metric": "test.multiple_timestamps_per_period.3",
-  	"timestamp": "1478021745",
-  	"value": "1.0",
+  	"timestamp": 1478021745,
+  	"value": 1.0,
   	"key": "YOURown32charSkylineAPIkeySecret"
   }
 
@@ -114,6 +114,8 @@ POST request
 The POST endpoint is `/flux/metric_data_post` and this accepts JSON data.  The
 json can have data for a single metric or for multiple metrics in a single POST.
 
+A successful POST will respond with no content and a 204 HTTP response code.
+
 Here is an example of the data a sinlge metric POST requires and an example POST
 request.
 
@@ -156,14 +158,16 @@ POST request for multiple metrics:
 
 .. code-block:: bash
 
-
   curl -vvv -u username:password -d '{"key":"YOURown32charSkylineAPIkeySecret","metrics":[{"metric":"vista.nodes.skyline-1.cpu.user","timestamp":1478021700,"value":1.0},{"metric":"vista.nodes.skyline-1.cpu.system","timestamp":1478021700,"value":0.2}]}' -H "Content-Type: application/json" -X POST https://skyline.example.org/flux/metric_data_post
+
 GET request
 -----------
 
 However if the flux instance in question is only receiving metrics on a local
 network or protected network and you do not mind sending the API key in
 plaintext, the GET method can be used.
+
+A successful GET request will respond with no content and a 204 HTTP response code.
 
 The `/flux/metric_data` endpoint is called via a GET request with the URI
 parameters as defined below:

--- a/skyline/flux/aggregator.py
+++ b/skyline/flux/aggregator.py
@@ -1,0 +1,334 @@
+import sys
+import os.path
+from os import kill
+from os import getpid
+import traceback
+from multiprocessing import Process
+from time import sleep, time
+from ast import literal_eval
+import random
+
+from logger import set_up_logging
+sys.path.append(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
+sys.path.insert(0, os.path.dirname(__file__))
+
+# @modified 20191115 - Branch #3262: py3
+# This prevents flake8 E402 - module level import not at top of file
+if True:
+    import settings
+    import flux
+    from skyline_functions import (
+        get_redis_conn, get_redis_conn_decoded)
+
+logger = set_up_logging(None)
+
+try:
+    SERVER_METRIC_PATH = '.%s' % settings.SERVER_METRICS_NAME
+    if SERVER_METRIC_PATH == '.':
+        SERVER_METRIC_PATH = ''
+except:
+    SERVER_METRIC_PATH = ''
+
+# Wrap per metric logging in if FLUX_VERBOSE_LOGGING
+try:
+    FLUX_VERBOSE_LOGGING = settings.FLUX_VERBOSE_LOGGING
+except:
+    FLUX_VERBOSE_LOGGING = True
+
+try:
+    FLUX_PERSIST_QUEUE = settings.FLUX_PERSIST_QUEUE
+except:
+    FLUX_PERSIST_QUEUE = False
+
+parent_skyline_app = 'flux'
+skyline_app = 'flux'
+skyline_app_graphite_namespace = 'skyline.%s%s.aggregator' % (parent_skyline_app, SERVER_METRIC_PATH)
+
+LOCAL_DEBUG = False
+
+
+class Aggregator(Process):
+    """
+    The aggregator processes metrics from the queue, aggregates them and sends
+    them to the httpMetricDataQueue queue for worker to submit to Graphite.
+    """
+    def __init__(self, parent_pid):
+        super(Aggregator, self).__init__()
+        self.redis_conn = get_redis_conn(skyline_app)
+        self.redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+
+        self.parent_pid = parent_pid
+        self.daemon = True
+        self.current_pid = getpid()
+
+    def check_if_parent_is_alive(self):
+        """
+        Self explanatory.
+        """
+        try:
+            kill(self.parent_pid, 0)
+        except:
+            logger.warn('warning :: parent process is dead')
+            exit(0)
+
+    def run(self):
+        """
+        Called when the process intializes.
+        """
+
+        logger.info('aggregator :: starting aggregator')
+
+        # Determine a primary aggregator
+        aggregator_pid = getpid()
+        main_process_pid = 0
+        try:
+            main_process_pid = int(self.redis_conn_decoded.get('flux.main_process_pid'))
+            if main_process_pid:
+                logger.info('aggregator :: main_process_pid found in Redis key - %s' % str(main_process_pid))
+        except:
+            main_process_pid = 0
+        if not main_process_pid:
+            logger.error('error :: aggregator :: no main_process_pid known, exiting')
+            sys.exit(1)
+
+        primary_aggregator_key = 'flux.primary_aggregator_pid.%s' % str(main_process_pid)
+        logger.info('aggregator :: starting primary_aggregator election using primary_aggregator_key: %s' % primary_aggregator_key)
+        sleep_for = random.uniform(0.1, 1.5)
+        logger.info('aggregator :: starting primary_aggregator election - sleeping for %s' % str(sleep_for))
+        sleep(sleep_for)
+        primary_aggregator_pid = 0
+        try:
+            primary_aggregator_pid = int(self.redis_conn_decoded.get(primary_aggregator_key))
+            if primary_aggregator_pid:
+                logger.info('aggregator :: primary_aggregator_pid found in Redis key - %s' % str(primary_aggregator_pid))
+        except:
+            primary_aggregator_pid = 0
+        if not primary_aggregator_pid:
+            try:
+                self.redis_conn.setex(primary_aggregator_key, 300, aggregator_pid)
+                primary_aggregator_pid = int(self.redis_conn_decoded.get(primary_aggregator_key))
+                logger.info('aggregator :: set self pid to primary_aggregator - %s' % str(primary_aggregator_pid))
+            except:
+                primary_aggregator_pid = 0
+        primary_aggregator = False
+        if primary_aggregator_pid == aggregator_pid:
+            primary_aggregator = True
+        logger.info('aggregator :: primary_aggregator_pid is set to %s, primary_aggregator: %s' % (
+            str(primary_aggregator_pid), str(primary_aggregator)))
+
+        last_flush = int(time()) - 59
+        remove_from_flux_queue_redis_set = []
+
+        # Populate API keys and tokens in memcache
+        # python-2.x and python3.x handle while 1 and while True differently
+        # while 1:
+        running = True
+        while running:
+            # Make sure Redis is up
+            redis_up = False
+            while not redis_up:
+                try:
+                    redis_up = self.redis_conn.ping()
+                except:
+                    logger.error('aggregator :: cannot connect to redis at socket path %s' % (settings.REDIS_SOCKET_PATH))
+                    sleep(2)
+                    try:
+                        self.redis_conn = get_redis_conn(skyline_app)
+                    except Exception as e:
+                        logger.error('error :: aggregator :: could not get_redis_conn - %s' % str(e))
+                    try:
+                        self.redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+                    except Exception as e:
+                        logger.error('error :: aggregator :: could not get_redis_conn_decoded - %s' % str(e))
+
+            try:
+                time_now = int(time())
+                while (time_now - last_flush) <= 59:
+                    sleep(1)
+                    remove_from_flux_queue_redis_set = []
+                    time_now = int(time())
+
+                primary_aggregator_pid = 0
+                try:
+                    primary_aggregator_pid = int(self.redis_conn_decoded.get(primary_aggregator_key))
+                    if primary_aggregator_pid:
+                        logger.info('aggregator :: primary_aggregator_pid found in Redis key - %s' % str(primary_aggregator_pid))
+                except:
+                    primary_aggregator_pid = 0
+                if not primary_aggregator_pid:
+                    try:
+                        self.redis_conn.setex(primary_aggregator_key, 300, aggregator_pid)
+                        primary_aggregator_pid = int(self.redis_conn_decoded.get(primary_aggregator_key))
+                        logger.info('aggregator :: set self pid to primary_aggregator - %s' % str(primary_aggregator_pid))
+                    except:
+                        primary_aggregator_pid = 0
+                primary_aggregator = False
+                if primary_aggregator_pid == aggregator_pid:
+                    primary_aggregator = True
+                logger.info('aggregator :: primary_aggregator_pid is set to %s, primary_aggregator: %s' % (
+                    str(primary_aggregator_pid), str(primary_aggregator)))
+
+                flux_aggregator_queue = []
+                if primary_aggregator:
+                    logger.info('aggregator :: checking for data to aggregate')
+                    try:
+                        flux_aggregator_queue = self.redis_conn_decoded.smembers('flux.aggregator.queue')
+                        logger.info('aggregator :: %s entries in flux.aggregator.queue to process' % str(len(flux_aggregator_queue)))
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: could not get the flux.aggregator.queue set from Redis')
+                else:
+                    logger.info('aggregator :: not primary, in standby to take over should the primary_aggregator fail')
+
+                flux_aggregator_queue_items = []
+                all_metrics = []
+                if flux_aggregator_queue:
+                    for flux_aggregator_queue_item_str in flux_aggregator_queue:
+                        try:
+                            flux_aggregator_queue_item = literal_eval(flux_aggregator_queue_item_str)
+                            all_metrics.append(flux_aggregator_queue_item[0])
+                            flux_aggregator_queue_items.append([flux_aggregator_queue_item, flux_aggregator_queue_item_str])
+                            # self.redis_conn.srem('flux.aggregator.queue', flux_aggregator_queue_item_str)
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: failed to evaluate item from flux.aggregator.queue Redis set')
+                metrics = list(set(all_metrics))
+                for metric in metrics:
+                    last_metric_flush = last_flush
+                    last_metric_flush_str = None
+                    try:
+                        last_metric_flush_str = self.redis_conn_decoded.hget('flux.aggregate_metrics.last_flush', metric)
+                        # Handle new metric without throwing an error if they do
+                        # not have an entry in the hash
+                        if last_metric_flush_str:
+                            last_metric_flush = int(last_metric_flush_str)
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: failed convert last_metric_flush_str value to an int from flux.aggregate_metrics.last_flush Redis hash for %s' % metric)
+                    if not last_metric_flush:
+                        # Handle new metric without throwing an error if they do
+                        # not have an entry in the hash
+                        logger.info('aggregator :: probable new metric - no last_metric_flush found in flux.aggregate_metrics.last_flush Redis hash for %s usinf last_flush' % metric)
+                        last_metric_flush = last_flush
+                    metric_aggregation_settings = {}
+                    try:
+                        metric_aggregation_settings_str = self.redis_conn_decoded.hget('metrics_manager.flux.aggregate_namespaces.settings', metric)
+                        metric_aggregation_settings = literal_eval(metric_aggregation_settings_str)
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: failed to determine aggregation_settings from metrics_manager.flux.aggregate_namespaces.settings Redis hash for %s' % metric)
+                    interval = 60
+                    try:
+                        interval = int(metric_aggregation_settings['interval'])
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: failed to get interval from metric_aggregation_settings for %s' % metric)
+                        interval = 60
+                    if (time_now - last_metric_flush) < interval:
+                        continue
+                    metric_values = []
+                    for flux_aggregator_queue_item in flux_aggregator_queue_items:
+                        if flux_aggregator_queue_item[0][0] != metric:
+                            continue
+                        # Discard any values older than the last metric flush
+                        if int(flux_aggregator_queue_item[0][2]) > last_metric_flush:
+                            metric_values.append(flux_aggregator_queue_item[0][1])
+                        try:
+                            self.redis_conn.srem('flux.aggregator.queue', flux_aggregator_queue_item[1])
+                            remove_from_flux_queue_redis_set.append(flux_aggregator_queue_item[1])
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: failed to remove item from flux.aggregator.queue Redis set - %s' % str(flux_aggregator_queue_item[1]))
+                    if not metric_aggregation_settings:
+                        logger.error('error :: no aggregation settings known for %s, discarding data' % metric)
+                        continue
+                    if metric_values:
+                        methods = []
+                        try:
+                            methods = metric_aggregation_settings['method']
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: failed to determine aggregation methods from metric_aggregation_settings - %s' % str(metric_aggregation_settings))
+                            methods = []
+                        for method in methods:
+                            try:
+                                metric_namespace = metric
+                                if metric_aggregation_settings['method_suffix']:
+                                    metric_namespace = '%s.%s' % (metric, method)
+                                aggregate_value = None
+                                if method == 'avg':
+                                    if len(metric_values) > 1:
+                                        aggregate_value = sum(metric_values) / len(metric_values)
+                                    else:
+                                        aggregate_value = metric_values[0]
+                                if method == 'sum':
+                                    aggregate_value = sum(metric_values)
+                                if method == 'max':
+                                    aggregate_value = max(metric_values)
+                                if method == 'min':
+                                    aggregate_value = min(metric_values)
+                                if aggregate_value is not None:
+                                    try:
+                                        backfill = False
+                                        metric_data = [metric_namespace, aggregate_value, (time_now - interval), backfill]
+                                        flux.httpMetricDataQueue.put(metric_data, block=False)
+                                        logger.info('aggregator :: added %s' % (str(metric_data)))
+                                        try:
+                                            self.redis_conn.hset('flux.aggregate_metrics.last_flush', metric, time_now)
+                                        except:
+                                            logger.error(traceback.format_exc())
+                                            logger.error('error :: aggregator :: failed to set last metric flush time in Redis hash flux.aggregate_metrics.last_flush')
+                                    except:
+                                        logger.error(traceback.format_exc())
+                                        logger.error('error :: aggregator :: failed to add aggregator data to flux.httpMetricDataQueue - %s' % str(metric_data))
+                            except:
+                                logger.error(traceback.format_exc())
+                                logger.error('error :: aggregator :: failed to aggregate metric_values by a method for %s' % str(metric))
+
+                last_flush = time_now
+
+                # flux_zero_fill_metrics = list(self.redis_conn_decoded.smembers('flux.zero_fill_metrics'))
+
+                if FLUX_PERSIST_QUEUE:
+                    redis_set_size = 0
+                    try:
+                        redis_set_size = self.redis_conn.scard('flux.queue')
+                    except:
+                        logger.error(traceback.format_exc())
+                        logger.error('error :: aggregator :: failed to determine size of flux.queue Redis set')
+                    logger.info('aggregator :: flux.queue Redis set size of %s before removal of %s items' % (
+                        str(redis_set_size), str(len(remove_from_flux_queue_redis_set))))
+                    if remove_from_flux_queue_redis_set:
+                        try:
+                            self.redis_conn.srem('flux.queue', *set(remove_from_flux_queue_redis_set))
+                            remove_from_flux_queue_redis_set = []
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: aggregator :: failed to remove multiple items from flux.queue Redis set')
+                        try:
+                            redis_set_size = self.redis_conn.scard('flux.queue')
+                        except:
+                            logger.error(traceback.format_exc())
+                            logger.error('error :: aggregator :: failed to determine size of flux.queue Redis set')
+                        logger.info('aggregator :: flux.queue Redis set size of %s after the removal of items' % (
+                            str(redis_set_size)))
+                        remove_from_flux_queue_redis_set = []
+
+                if primary_aggregator:
+                    try:
+                        self.redis_conn.setex(primary_aggregator_key, 300, aggregator_pid)
+                        primary_aggregator_pid = int(self.redis_conn_decoded.get(primary_aggregator_key))
+                        logger.info('aggregator :: set self pid to primary_aggregator - %s' % str(primary_aggregator_pid))
+                        logger.info('aggregator :: set Redis primary_aggregator_key key to self pid to primary_aggregator - %s' % str(primary_aggregator_pid))
+                    except Exception as e:
+                        logger.error('error :: aggregator :: failed to set Redis primary_aggregator_key key to self pid - %s' % (str(e)))
+
+            except NotImplementedError:
+                pass
+            except KeyboardInterrupt:
+                logger.info('aggregator :: server has been issued a user signal to terminate - KeyboardInterrupt')
+            except SystemExit:
+                logger.info('aggregator :: server was interrupted - SystemExit')
+            except Exception as e:
+                logger.error(traceback.format_exc())
+                logger.error('error :: aggregator :: %s' % (str(e)))

--- a/skyline/flux/flux.py
+++ b/skyline/flux/flux.py
@@ -23,6 +23,9 @@ if True:
     from worker import Worker
     from populate_metric import PopulateMetric
     from populate_metric_worker import PopulateMetricWorker
+    # @added 20210406 - Feature #4004: flux - aggregator.py and FLUX_AGGREGATE_NAMESPACES
+    from aggregator import Aggregator
+
     # @added 20200517 - Feature #3550: flux.uploaded_data_worker
     try:
         flux_process_uploads = settings.FLUX_PROCESS_UPLOADS
@@ -96,6 +99,9 @@ else:
         logger.info('flux :: there were no items in the flux.queue Redis set to add to the queue')
     else:
         logger.info('flux :: FLUX_PERSIST_QUEUE is set to %s, not persisting' % str(FLUX_PERSIST_QUEUE))
+
+logger.info('flux :: starting %s aggregator processes' % str(settings.FLUX_WORKERS))
+Aggregator(pid).start()
 
 logger.info('flux :: starting %s worker/s' % str(settings.FLUX_WORKERS))
 Worker(httpMetricDataQueue, pid).start()

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -3218,6 +3218,56 @@ FLUX_ZERO_FILL_NAMESPACES = []
 
 """
 
+FLUX_LAST_KNOWN_VALUE_NAMESPACES = []
+"""
+:var FLUX_LAST_KNOWN_VALUE_NAMESPACES: For each namespace or namespace elements
+    declared in this list, flux will send the last value if no data is recieved
+    for a metric in the namespace in the last 60 seconds. The namespaces
+    declared here can be absolute metric names, elements or a regex of the
+    namespace.
+:vartype FLUX_LAST_KNOWN_VALUE_NAMESPACES: list
+
+- **Example**::
+
+    FLUX_LAST_KNOWN_VALUE_NAMESPACES = [
+        'external_sites.www_example_com.users',
+        'external_sites.shop_example_com.products',
+    ]
+
+"""
+
+FLUX_AGGREGATE_NAMESPACES = {}
+"""
+:var FLUX_AGGREGATE_NAMESPACES: For each namespace or namespace elements
+    declared in this dict, flux/listen will send data points received to
+    flux/aggregator which will then submit metrics to flux/worker at every
+    interval, aggregating by the defined method/s. If multiple methods are used
+    flux will submit a metric per method defined.
+:vartype FLUX_AGGREGATE_NAMESPACES: dict
+
+- **Example**::
+
+    FLUX_AGGREGATE_NAMESPACES = {
+        'mysite.events.loadtime': {
+            'method': ['avg'],
+            'interval': 60,
+            'zero_fill': True,
+            'last_known_value': False,
+            'method_suffix': False},
+        'mysite.events.pageloads': {
+            'method': ['avg', 'sum', 'high'],
+            'interval': 60,
+            'zero_fill': False,
+            'last_known_value': False,
+            'method_suffix': True},
+        'warehouse1.kwh.meter.reading': {
+            'method': ['avg'],
+            'interval': 60,
+            'zero_fill': False,
+            'last_known_value': False,
+            'method_suffix': False},
+    }
+"""
 
 FLUX_SEND_TO_STATSD = False
 """


### PR DESCRIPTION
IssueID #4004: flux - aggregator.py and FLUX_AGGREGATE_NAMESPACES
IssueID #3994: Panorama - mirage not anomalous
IssueID #4002: Change flux FLUX_ZERO_FILL_NAMESPACES to pickle

- Added flux/aggregator.py (4004)
- Better handle multiple workers with the introduction of primary_worker, etc
  roles (4004)
- Added FLUX_LAST_KNOWN_VALUE_NAMESPACES and FLUX_AGGREGATE_NAMESPACES to
  settings.py (4004)
- Changes and corrections to FLUX_ZERO_FILL_NAMESPACES in worker.py (#4002)
- metrics_manager changes to manage the flux aggregator Redis resources (3994)
- metrics_manager changes to manage the mirage.panorama.not_anomalous_metrics
  Redis hash (3994)

Added:
skyline/flux/aggregator.py
Modified:
docs/flux.rst
skyline/analyzer/metrics_manager.py
skyline/flux/flux.py
skyline/flux/gunicorn.py
skyline/flux/listen.py
skyline/flux/uploaded_data_worker.py
skyline/flux/worker.py
skyline/settings.py