### PR TITLE
BATCH_METRICS_CUSTOM_FULL_DURATIONS setting

### DIFF
--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -1561,11 +1561,30 @@ analyzer_batch to fake Mirage analysed for historical data.  analyzer_batch
 roomba will use this setting for the euthanize older than value if the metric
 name is in a metric namespace found in a list.
 
-- **Tuple example**::
+- **List example**::
 
     ROOMBA_BATCH_METRICS_CUSTOM_DURATIONS = [
         ['test.app6.requests.10minutely', 604800],
     ]
+
+"""
+
+BATCH_METRICS_CUSTOM_FULL_DURATIONS = {}
+"""
+:var BATCH_METRICS_CUSTOM_FULL_DURATIONS: This is ONLY applicable to metrics
+    declared in :mod:`settings.ROOMBA_BATCH_METRICS_CUSTOM_DURATIONS` that are
+    being back filled.  Metrics that are being backfilled and not managed by
+    roomba, but managed by analyzer_batch may have a very long custom duration
+    period, but may have a shorter FULL_DURATION period.  In order to backfill
+    and analyse at the correct full duration for the metric, the metric full
+    duration for analysis (not for analyzer batch roomba) can be declared here.
+:vartype BATCH_METRICS_CUSTOM_FULL_DURATIONS: dict
+
+- **dict example**::
+
+    BATCH_METRICS_CUSTOM_FULL_DURATIONS = {
+        'test.app6.requests.10minutely': 259200,
+    }
 
 """
 

--- a/skyline/validate_settings.py
+++ b/skyline/validate_settings.py
@@ -2165,6 +2165,17 @@ def validate_settings_variables(current_skyline_app):
         invalid_variables = True
 
     try:
+        if not isinstance(settings.BATCH_METRICS_CUSTOM_FULL_DURATIONS, dict):
+            print('error :: BATCH_METRICS_CUSTOM_FULL_DURATIONS in settings.py is not a dict')
+            invalid_variables = True
+    except AttributeError:
+        print('error :: BATCH_METRICS_CUSTOM_FULL_DURATIONS is not defined in settings.py')
+        invalid_variables = True
+    except Exception as e:
+        print('error :: BATCH_METRICS_CUSTOM_FULL_DURATIONS is not defined in settings.py - %s' % e)
+        invalid_variables = True
+
+    try:
         if not isinstance(settings.PROMETHEUS_SETTINGS, dict):
             print('error :: PROMETHEUS_SETTINGS in settings.py is not a dict')
             invalid_variables = True


### PR DESCRIPTION
IssueID #4328: BATCH_METRICS_CUSTOM_FULL_DURATIONS

- New BATCH_METRICS_CUSTOM_FULL_DURATIONS setting

Modified:
skyline/settings.py
skyline/validate_settings.py