### PR TITLE
BATCH_METRICS_CUSTOM_FULL_DURATIONS

### DIFF
--- a/skyline/external_alert_configs.py
+++ b/skyline/external_alert_configs.py
@@ -311,6 +311,9 @@ def get_external_alert_configs(current_skyline_app):
                 second_order_resolution = second_order_resolution_hours * 3600
             except:
                 second_order_resolution = 0
+                # @added 20211128 - Feature #4328: BATCH_METRICS_CUSTOM_FULL_DURATIONS
+                # Added missing second_order_resolution_hours
+                second_order_resolution_hours = 0
             config_id = 'internal-%s' % str(index)
             internal_alert_config = {
                 'id': config_id,

--- a/skyline/horizon/roomba.py
+++ b/skyline/horizon/roomba.py
@@ -98,7 +98,7 @@ class Roomba(Thread):
         except:
             # @added 20201203 - Bug #3856: Handle boring sparsely populated metrics in derivative_metrics
             # Log warning
-            logger.warn('warning :: parent process is dead')
+            logger.warning('warning :: parent process is dead')
             exit(0)
 
     def vacuum(self, i, namespace, duration):
@@ -121,7 +121,14 @@ class Roomba(Thread):
         #                   Feature #3486: analyzer_batch
         if ROOMBA_DO_NOT_PROCESS_BATCH_METRICS and BATCH_PROCESSING and BATCH_PROCESSING_NAMESPACES:
             try:
-                batch_metrics = list(self.redis_conn_decoded.smembers('aet.analyzer.batch_processing_metrics'))
+                # @modified 20211127 - Feature #4328: BATCH_METRICS_CUSTOM_FULL_DURATIONS
+                # Ensure that known and new batch_processing_metrics are
+                # accounted for
+                # batch_metrics = list(self.redis_conn_decoded.smembers('aet.analyzer.batch_processing_metrics'))
+                batch_metrics1 = list(self.redis_conn_decoded.smembers('aet.analyzer.batch_processing_metrics'))
+                batch_metrics2 = list(self.redis_conn_decoded.smembers('analyzer.batch_processing_metrics'))
+                all_batch_metrics = batch_metrics1 + batch_metrics2
+                batch_metrics = list(set(all_batch_metrics))
             except:
                 logger.error('error - failed to get Redis set aet.analyzer.batch_processing_metrics')
                 batch_metrics = []


### PR DESCRIPTION
IssueID #4328: BATCH_METRICS_CUSTOM_FULL_DURATIONS
IssueID #3566: custom_algorithms

- In algorithms_batch.py and mirage_algorithms.py
  Handle BATCH_METRICS_CUSTOM_FULL_DURATIONS,
  Calculate the equivalent of the last hour and handle daily frequency data,
  Added option to run_before_3sigma for custom_algorithms,
  If custom_algorithms were run and did not trigger reset the consensus,
- In analyzer.py
  Determine batch_metrics_list from Redis aet.analyzer.batch_processing_metrics set,
  Attempt to get resolution from Redis,
  Update alert.paused cache_key name interpolation
- Added missing second_order_resolution_hours to external_alert_configs.py
- Ensure that known and new batch_processing_metrics are accounted for in
  roomba.py

Modified:
skyline/analyzer/algorithms_batch.py
skyline/analyzer/algorithms_batch.py
skyline/analyzer/analyzer.py
skyline/external_alert_configs.py
skyline/horizon/roomba.py
skyline/mirage/mirage_algorithms.py