### PR TITLE
Manage thunder.events

### DIFF
--- a/skyline/functions/redis/update_set.py
+++ b/skyline/functions/redis/update_set.py
@@ -50,8 +50,11 @@ def update_redis_set(
             function_str, redis_set, e))
     try:
         redis_conn.srem(redis_set, str(original_data_str))
-        current_logger.info('removed item from Redis set %s - %s' % (
-            redis_set, str(original_data_str)))
+        # @added 20220110 - Bug #4364: Prune old thunder.events
+        #                   Branch #1444: thunder
+        if log:
+            current_logger.info('removed item from Redis set %s - %s' % (
+                redis_set, str(original_data_str)))
     except Exception as e:
         if not log:
             current_skyline_app_logger = current_skyline_app + 'Log'
@@ -62,8 +65,11 @@ def update_redis_set(
     if update_data_str != 'remove':
         try:
             redis_conn.sadd(redis_set, str(update_data_str))
-            current_logger.info('added updated item to Redis set %s - %s' % (
-                redis_set, str(update_data_str)))
+            # @added 20220110 - Bug #4364: Prune old thunder.events
+            #                   Branch #1444: thunder
+            if log:
+                current_logger.info('added updated item to Redis set %s - %s' % (
+                    redis_set, str(update_data_str)))
         except Exception as e:
             if not log:
                 current_skyline_app_logger = current_skyline_app + 'Log'

--- a/skyline/thunder/thunder.py
+++ b/skyline/thunder/thunder.py
@@ -479,7 +479,10 @@ class Thunder(Thread):
                 thunder_events = []
                 if redis_is_up:
                     try:
-                        thunder_events = self.redis_conn_decoded.smembers(thunder_redis_set)
+                        # @modified 20220110 - Bug #4364: Prune old thunder.events
+                        #                      Branch #1444: thunder
+                        # thunder_events = self.redis_conn_decoded.smembers(thunder_redis_set)
+                        thunder_events = list(self.redis_conn_decoded.smembers(thunder_redis_set))
                     except Exception as e:
                         logger.error('error :: could not query Redis for set %s - %s' % (thunder_redis_set, e))
 
@@ -819,7 +822,9 @@ class Thunder(Thread):
                                     logger.info('added Redis failover - failover_key_file - %s' % (failover_key_file))
                                 except Exception as e:
                                     logger.error('error :: failed to add Redis failover failover_key_file - %s - %s' % (failover_key_file, e))
-                            redis_item = event_item
+                            # @modified 20220110 - Bug #4364: Prune old thunder.events
+                            #                      Branch #1444: thunder
+                            # redis_item = event_item
                             break
 
                 if not validated_event_details:


### PR DESCRIPTION
IssueID #4364: Prune old thunder.events
IssueID #1444: thunder

- Prune old thunder.events
- Fix log logic in redis/update_set.py

Modified:
skyline/analyzer/metrics_manager.py
skyline/functions/redis/update_set.py
skyline/thunder/thunder.py