### PR TITLE
Manage thunder.events

### DIFF
--- a/skyline/thunder/thunder.py
+++ b/skyline/thunder/thunder.py
@@ -952,7 +952,7 @@ class Thunder(Thread):
                                 remove_item = thunder_event_str
                         if remove_item:
                             # Remove event
-                            logger.error('error :: removing event from thunder.events Redis set as the event is older than 86400 seconds. event:%s' % (
+                            logger.info('removing event from thunder.events Redis set as the event is older than 86400 seconds. event: %s' % (
                                 str(thunder_event)))
                             try:
                                 update_redis_set(


### PR DESCRIPTION
IssueID #4364: Prune old thunder.events
IssueID #1444: thunder

- Correct log context

Modified:
skyline/thunder/thunder.py