### PR TITLE
IssueID #4076: CUSTOM_STALE_PERIOD

### DIFF
--- a/skyline/functions/settings/get_custom_stale_period.py
+++ b/skyline/functions/settings/get_custom_stale_period.py
@@ -48,7 +48,7 @@ def custom_stale_period(
         current_logger.error('error :: %s :: failed to parse STALE_PERIOD from settings - %s' % (
             function_str, e))
         stale_period = 500
-    custom_stale_period = int(stale_period)
+    custom_stale_period_int = int(stale_period)
 
     custom_stale_period_dict = {}
     try:
@@ -127,7 +127,7 @@ def custom_stale_period(
     if pattern_match:
         try:
             matched_namespace = matched_by['matched_namespace']
-            custom_stale_period = int(float(custom_stale_period_dict[matched_namespace]))
+            custom_stale_period_int = int(float(custom_stale_period_dict[matched_namespace]))
             if log:
                 if current_skyline_app == 'analyzer':
                     current_logger.info('metrics_manager :: %s :: custom_stale_period found for %s: %s' % (
@@ -136,7 +136,7 @@ def custom_stale_period(
                     current_logger.info('%s :: custom_stale_period found for %s: %s' % (
                         function_str, base_name, str(custom_stale_period)))
         except ValueError:
-            custom_stale_period = stale_period
+            custom_stale_period_int = stale_period
         except Exception as e:
             if not log:
                 current_skyline_app_logger = current_skyline_app + 'Log'
@@ -144,6 +144,6 @@ def custom_stale_period(
             current_logger.error(traceback.format_exc())
             current_logger.error('error :: %s :: failed to parse CUSTOM_STALE_PERIOD from settings - %s' % (
                 function_str, e))
-            custom_stale_period = stale_period
+            custom_stale_period_int = stale_period
 
-    return custom_stale_period
+    return custom_stale_period_int

--- a/skyline/functions/thunder/stale_metrics.py
+++ b/skyline/functions/thunder/stale_metrics.py
@@ -248,7 +248,9 @@ def thunder_stale_metrics(current_skyline_app, log=True):
                 external_parent_namespaces_stale_periods[parent_namespace]['expiry'] = int(expiry)
     external_parent_namespaces = []
     if external_parent_namespaces:
-        external_parent_namespaces = list(external_parent_namespaces.keys())
+        # external_parent_namespaces = list(external_parent_namespaces.keys())
+        external_parent_namespaces = list(external_parent_namespaces_stale_periods.keys())
+
     parent_namespace_metrics_processed = []
     custom_stale_period_namespaces = []
     # Sort the list by the namespaces with the most elements to the least as


### PR DESCRIPTION
- Rename custom_stale_period to custom_stale_period_int
- Correct list from external_parent_namespaces to
  external_parent_namespaces_stale_periods

Modified:
skyline/functions/settings/get_custom_stale_period.py
skyline/functions/thunder/stale_metrics.py