### PR TITLE
IssueID #4400: flux - quota

### DIFF
--- a/skyline/flux/aggregator.py
+++ b/skyline/flux/aggregator.py
@@ -279,6 +279,15 @@ class Aggregator(Process):
                                 metric_namespace = metric
                                 if metric_aggregation_settings['method_suffix']:
                                     metric_namespace = '%s.%s' % (metric, method)
+                                else:
+                                    # @added 20220126 - Feature #4400: flux - quota
+                                    # If method_suffix is not set but multiple
+                                    # methods are being used, method_suffix
+                                    # must be applied, otherwise the metric will
+                                    # have all the method values submitted to a
+                                    # single metric name.
+                                    if len(methods) > 1:
+                                        metric_namespace = '%s.%s' % (metric, method)
                                 aggregate_value = None
                                 if method == 'avg':
                                     if len(metric_values) > 1:

--- a/skyline/functions/flux/reload_flux.py
+++ b/skyline/functions/flux/reload_flux.py
@@ -61,7 +61,7 @@ def reload_flux(current_skyline_app, flux_pid_file):
     current_logger.info('%s :: flux_pid: %s, kill_winch_main_pid: %s' % (function_str, str(flux_pid), str(kill_winch_main_pid)))
     kill_quit_main_pid = subprocess.getstatusoutput('/usr/bin/kill -s QUIT %s' % str(flux_pid))
     current_logger.info('%s :: flux_pid: %s, kill_quit_main_pid: %s' % (function_str, str(flux_pid), str(kill_quit_main_pid)))
-    sleep(3)
+    sleep(10)
     current_pids = subprocess.getoutput("ps aux | grep flux | grep gunicorn | tr -s ' ' ',' | cut -d',' -f2").split('\n')
     for pid in original_pids:
         if pid in current_pids:

--- a/skyline/functions/settings/external_settings_aggregation.py
+++ b/skyline/functions/settings/external_settings_aggregation.py
@@ -1,0 +1,52 @@
+import logging
+import traceback
+
+
+# @added 20220128 - Feature #4404: flux - external_settings - aggregation
+def external_settings_aggregation(
+        current_skyline_app, external_settings, log=False):
+    """
+    Determine the namespace aggregations defined in external_settings
+
+    :param current_skyline_app: the app calling the function
+    :param external_settings: the external_settings dict
+    :param log: whether to log or not, optional, defaults to False
+    :type current_skyline_app: str
+    :type external_settings: dict
+    :type log: boolean
+    :return: external_settings_aggregations
+    :rtype: dict
+
+    """
+
+    function_str = 'functions.settings.external_settings_aggregation'
+    if log:
+        current_skyline_app_logger = current_skyline_app + 'Log'
+        current_logger = logging.getLogger(current_skyline_app_logger)
+    else:
+        current_logger = None
+
+    external_settings_aggregations = {}
+
+    for config_id in list(external_settings.keys()):
+        try:
+            aggregate = None
+            try:
+                aggregate = external_settings[config_id]['aggregate']
+            except KeyError:
+                aggregate = None
+            if not aggregate:
+                continue
+            for namespace_key in list(external_settings[config_id]['aggregate'].keys()):
+                external_settings_aggregations[namespace_key] = external_settings[config_id]['aggregate'][namespace_key]
+        except Exception as e:
+            if not log:
+                current_skyline_app_logger = current_skyline_app + 'Log'
+                current_logger = logging.getLogger(current_skyline_app_logger)
+            current_logger.error(traceback.format_exc())
+            current_logger.error('error :: %s :: failed to parse external_settings[\'%s\'] for aggregate - %s' % (
+                function_str, config_id, e))
+    if log:
+        current_logger.info('%s :: %s namespaces found to aggregate in external_settings' % (
+            function_str, str(len(external_settings_aggregations))))
+    return external_settings_aggregations

--- a/skyline/functions/settings/get_external_settings.py
+++ b/skyline/functions/settings/get_external_settings.py
@@ -85,4 +85,18 @@ def get_external_settings(current_skyline_app, namespace=None, log=False):
                     config_id, e))
         external_settings = namespace_external_settings
 
+    # @added 20220128 - Feature #4376: webapp - update_external_settings
+    if external_settings and current_skyline_app == 'webapp':
+        redacted_tokens_external_settings = {}
+        for config_id in list(external_settings.keys()):
+            if log:
+                current_logger.info('get_external_settings :: redacting tokens for webapp API request')
+            redacted_tokens_external_settings[config_id] = {}
+            for key in list(external_settings[config_id].keys()):
+                if 'token' in key:
+                    redacted_tokens_external_settings[config_id][key] = 'REDACTED'
+                else:
+                    redacted_tokens_external_settings[config_id][key] = external_settings[config_id][key]
+        external_settings = redacted_tokens_external_settings
+
     return external_settings

--- a/skyline/settings.py
+++ b/skyline/settings.py
@@ -3739,6 +3739,27 @@ FLUX_AGGREGATE_NAMESPACES = {}
     flux will submit a metric per method defined.
 :vartype FLUX_AGGREGATE_NAMESPACES: dict
 
+Each namespace is defined in a dict with the following keys:
+method: a list of methods to apply to the metric aggregation, valid methods are
+avg, sum, min and max.  More than one method can be applied which will result a
+metric being submitted for each method. If multiple methods are applied
+method_suffix must be set to True and if not is automatically set.
+interval: the interval in seconds at which to aggregate the metric data.  If a
+datapoint is received for a metric every 5 seconds and the interval is set to
+60, flux will submit the aggregated value/s for the metric to Graphite every
+60 seconds.
+zero_fill: if this is set to True flux will submit a 0 to Graphite every
+interval seconds if no data is received for the metric in the interval period.
+Note a namespace can either be set to zero_fill or last_known_value, not both.
+last_known_value: if this is set to True, if flux does not receive data for a
+metric in the interval period, flux will submit the last value that it submitted
+to Graphite for the current interval period.  This is like a gauge metric.
+Note a namespace can either be set to zero_fill or last_known_value, not both.
+method_suffix: if set to True, flux will suffix the metric name with the method,
+for example, mysite.events.pageloads.avg, if mulitple methods are declared this
+must be set to True and if not set will be automatically added otherwise the
+metric will have all the method values submitted to a single metric name.
+
 - **Example**::
 
     FLUX_AGGREGATE_NAMESPACES = {
@@ -3749,7 +3770,7 @@ FLUX_AGGREGATE_NAMESPACES = {}
             'last_known_value': False,
             'method_suffix': False},
         'mysite.events.pageloads': {
-            'method': ['avg', 'sum', 'high'],
+            'method': ['avg', 'sum', 'max', 'min'],
             'interval': 60,
             'zero_fill': False,
             'last_known_value': False,
@@ -3772,6 +3793,22 @@ FLUX_EXTERNAL_AGGREGATE_NAMESPACES = False
 :vartype FLUX_EXTERNAL_AGGREGATE_NAMESPACES: boolean
 """
 
+FLUX_NAMESPACE_QUOTAS = {}
+"""
+:var FLUX_NAMESPACE_QUOTAS: ADVANCED FEATURE.  A top level namespace can be
+    limited in terms of how many metrics flux will accept for the namespace.
+    This only applies to metrics sent to flux with a FLUX_API_KEYS namespace.
+    It cannot be applied to metrics sent to flux using the FLUX_SELF_API_KEY and
+    currently only applies to POSTs with multiple metrics.
+:vartype FLUX_NAMESPACE_QUOTAS: dict
+
+- **Example**::
+
+    FLUX_NAMESPACE_QUOTAS = {
+        'warehouse-1': 300,
+        'warehouse-2': 30,
+    }
+"""
 
 FLUX_SEND_TO_STATSD = False
 """

--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -473,6 +473,70 @@ Or if no metrics if no metrics are derivative metrics <code>{"data":{"metrics":[
 		    </tbody>
 		  </table>
 
+	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/api?external_settings</span></span></h4>
+  		  <table class="table table-hover">
+  		    <thead>
+  		      <tr>
+  		        <th>Name</th>
+  		        <th>Description</th>
+  		      </tr>
+  		    </thead>
+  		    <tbody>
+  		      <tr>
+  		        <td>Description:</td>
+  		        <td>Returns a dictionary of external_settings as a json object. Optionally you can filter on namepsace. Tokens are REDACTED</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Endpoint:</td>
+  		        <td><a target='_blank' href="/api?external_settings">/api?external_settings</a></td>
+  		      </tr>
+  		      <tr>
+  		        <td>Method:</td>
+  		        <td>GET</td>
+  		      </tr>
+  		      <tr>
+  		        <td>Request example:</td>
+		          <td><code>/api?external_settings</code><br>
+              <code>/api?external_settingss&cluster_data=true</code> [optional for clustered Skyline]<br>
+              <code>/api?external_settings&namespace=[namespace]</code> [optional]<br>
+              </td>
+  		      </tr>
+  		      <tr>
+  		        <td>Responses:</td>
+  		        <td>200 - json response, example
+                  <code>
+{
+  "data": {
+      "alert_on_no_data": {
+        "enabled": true,
+        "expiry": 1800,
+        "stale_period": 300
+      },
+      "alert_on_stale_metrics": {
+        "enabled": true,
+        "expiry": 0,
+        "stale_period": 900
+      },
+      "flux_token": "REDACTED",
+      "full_duration": 86400,
+      "id": "test_external_settings",
+      "learn_full_duration_seconds": 2592000,
+      "namespace": "skyline-test-external-settings",
+      "retention_1_period_seconds": 604800,
+      "retention_1_resolution_seconds": 60,
+      "retention_2_period_seconds": 63072000,
+      "retention_2_resolution_seconds": 600,
+      "second_order_resolution_seconds": 604800,
+      "thunder_alert_endpoint": "http://127.0.0.1:1500/mock_api?alert_reciever",
+      "thunder_alert_token": "REDACTED"
+  },
+  "status": {"cluster_data": false, "request_time": 0.0032482019159942865, "response": 200}
+}</code><br>
+              </td>
+  		      </tr>
+		    </tbody>
+		  </table>
+
 	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/flux/metric_data</span></span></h4>
   		  <table class="table table-hover">
   		    <thead>
@@ -496,11 +560,11 @@ Or if no metrics if no metrics are derivative metrics <code>{"data":{"metrics":[
   		      </tr>
   		      <tr>
   		        <td>Parameters:</td>
-  		        <td>metric=[metric_name | str | <font color=red>required</font>]</br>
-                  timestamp=[unix timestamp | int | <font color=red>required</font>]</br>
-                  value=[value | float | <font color=red>required</font>]</br>
-                  key=[API key | str | <font color=red>required</font>]</br>
-                  fill=[whether this is backfill | boolean | optional]</br>
+  		        <td>metric=[metric_name | str | <font color=red>required</font>]<br>
+                  timestamp=[unix timestamp | int | <font color=red>required</font>]<br>
+                  value=[value | float | <font color=red>required</font>]<br>
+                  key=[API key | str | <font color=red>required</font>]<br>
+                  fill=[whether this is backfill | boolean | optional]<br>
               </td>
   		      </tr>
   		      <tr>


### PR DESCRIPTION
IssueID #4404: flux - external_settings - aggregation
IssueID #4324: flux - reload external_settings
IssueID #4376: webapp - update_external_settings

- Determine flux namespace quotas in metrics_manager with
  metrics_manager.flux.namespace_quotas hash (#4400)
- Handle external_settings_aggregations settings from EXTERNAL_SETTINGS in
  metrics_manager with metrics_manager.flux.aggregate_namespaces hash (#4404)
- Move flux_reload from webapp to metrics_manager using
  skyline.external_settings.update.metrics_manager key
- In flux aggregator if method_suffix is not set but multiple methods are being
  used, method_suffix must be applied, otherwise the metric will have all the
  method values submitted to a single metric name (#4400)
- Handle quota and aggregation in flux listen (#4400, #4404)
- Change flux_reload sleep from 3 to 10
- Redact tokens in webapp external_settings API requests (#4376)
- Enable thunder/no_data to consider external settings changes (#4376)
- Added api/external_settings method to webapp (#4376)
- Added FLUX_AGGREGATE_NAMESPACES docstrings to settings (#4404)
- Added FLUX_NAMESPACE_QUOTAS to settings (#4400)

Added:
skyline/functions/settings/external_settings_aggregation.py
Modified:
skyline/analyzer/metrics_manager.py
skyline/flux/aggregator.py
skyline/flux/listen.py
skyline/functions/flux/reload_flux.py
skyline/functions/settings/get_external_settings.py
skyline/functions/thunder/no_data.py
skyline/settings.py
skyline/webapp/templates/api.html
skyline/webapp/webapp.py