### PR TITLE
Add RedisErrorLogHandler to agents

### DIFF
--- a/skyline/analyzer/agent.py
+++ b/skyline/analyzer/agent.py
@@ -19,6 +19,8 @@ if True:
     from analyzer import Analyzer
     from metrics_manager import Metrics_Manager
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'analyzer'
 skyline_app_logger = '%sLog' % skyline_app
@@ -87,6 +89,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/analyzer/agent_batch.py
+++ b/skyline/analyzer/agent_batch.py
@@ -18,6 +18,8 @@ if True:
     import settings
     from analyzer_batch import AnalyzerBatch
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'analyzer_batch'
 skyline_app_logger = '%sLog' % skyline_app
@@ -78,6 +80,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/boundary/agent.py
+++ b/skyline/boundary/agent.py
@@ -16,6 +16,8 @@ if True:
     from boundary import Boundary
     from boundary_algorithms import *
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'boundary'
 skyline_app_logger = '%sLog' % skyline_app
@@ -66,6 +68,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/crucible/agent.py
+++ b/skyline/crucible/agent.py
@@ -16,6 +16,8 @@ if True:
     from crucible import Crucible
     from crucible_algorithms import run_algorithms
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 python_version = int(sys.version_info[0])
 
@@ -95,6 +97,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     try:

--- a/skyline/flux/logger.py
+++ b/skyline/flux/logger.py
@@ -13,6 +13,8 @@ sys.path.insert(0, os.path.dirname(__file__))
 # This prevents flake8 E402 - module level import not at top of file
 if True:
     import settings
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'flux'
 skyline_app_logger = '%sLog' % skyline_app
@@ -62,5 +64,14 @@ def set_up_logging(app):
         # logging.basicConfig(filename='app.log', filemode='w', format='%(name)s - %(levelname)s - %(message)s')
         # To print only
         # logging.basicConfig(format=format, level=logging.DEBUG)
+
+        # @added 20220328 - Feature #4018: thunder - skyline.errors
+        # For every error logged set a count in the app Redis key which is consumed
+        # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+        # metric
+        redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+        redis_error_log_handler.setLevel(logging.ERROR)
+        redis_error_log_handler.setFormatter(formatter)
+        logger.addHandler(redis_error_log_handler)
 
     return logger

--- a/skyline/ionosphere/agent.py
+++ b/skyline/ionosphere/agent.py
@@ -25,6 +25,8 @@ if True:
     import settings
     from ionosphere import Ionosphere
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'ionosphere'
 skyline_app_logger = skyline_app + 'Log'
@@ -114,6 +116,15 @@ if __name__ == "__main__":
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/luminosity/agent.py
+++ b/skyline/luminosity/agent.py
@@ -28,10 +28,11 @@ if True:
         from cloudburst import Cloudburst
         # @added 20210806 - Feature #4164: luminosity - cloudbursts
         from cloudbursts import Cloudbursts
-
     # @added 20210929 - Feature #4264: luminosity - cross_correlation_relationships
     if settings.LUMINOSITY_RELATED_METRICS:
         from related_metrics import RelatedMetrics
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'luminosity'
 skyline_app_logger = skyline_app + 'Log'
@@ -132,6 +133,15 @@ if __name__ == "__main__":
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/mirage/agent.py
+++ b/skyline/mirage/agent.py
@@ -19,6 +19,8 @@ if True:
     from mirage import Mirage
     from mirage_algorithms import *
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'mirage'
 skyline_app_logger = '%sLog' % skyline_app
@@ -66,6 +68,15 @@ def run():
 
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/panorama/agent.py
+++ b/skyline/panorama/agent.py
@@ -23,6 +23,8 @@ if True:
     import settings
     from panorama import Panorama
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'panorama'
 skyline_app_logger = skyline_app + 'Log'
@@ -89,6 +91,15 @@ if __name__ == "__main__":
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/snab/agent.py
+++ b/skyline/snab/agent.py
@@ -16,6 +16,8 @@ if True:
     import settings
     from snab import SNAB
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'snab'
 skyline_app_logger = '%sLog' % skyline_app
@@ -74,6 +76,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/snab/snab_flux_load_test_agent.py
+++ b/skyline/snab/snab_flux_load_test_agent.py
@@ -15,6 +15,8 @@ sys.path.insert(0, os.path.dirname(__file__))
 if True:
     import settings
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
     from snab_flux_load_test import SNAB_flux_load_test
 
 skyline_app = 'snab_flux_load_test'

--- a/skyline/thunder/agent.py
+++ b/skyline/thunder/agent.py
@@ -16,6 +16,8 @@ if True:
     from thunder import Thunder
     from thunder_rolling import RollingThunder
     from validate_settings import validate_settings_variables
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
 
 skyline_app = 'thunder'
 skyline_app_logger = '%sLog' % skyline_app
@@ -77,6 +79,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)

--- a/skyline/vista/agent.py
+++ b/skyline/vista/agent.py
@@ -17,6 +17,8 @@ if True:
         from fetcher import Fetcher
         from worker import Worker
         from validate_settings import validate_settings_variables
+        # @added 20220328 - Feature #4018: thunder - skyline.errors
+        from functions.redis.RedisErrorLogHandler import RedisErrorLogHandler
     except:
         print(traceback.format_exc())
         print('failed to import Skyline modules')
@@ -88,6 +90,15 @@ def run():
                                                     target=handler)
     handler.setFormatter(formatter)
     logger.addHandler(memory_handler)
+
+    # @added 20220328 - Feature #4018: thunder - skyline.errors
+    # For every error logged set a count in the app Redis key which is consumed
+    # by thunder and creates the sskyline.<hostname>.<skyline_app>.logged_errors
+    # metric
+    redis_error_log_handler = RedisErrorLogHandler(skyline_app)
+    redis_error_log_handler.setLevel(logging.ERROR)
+    redis_error_log_handler.setFormatter(formatter)
+    logger.addHandler(redis_error_log_handler)
 
     # Validate settings variables
     valid_settings = validate_settings_variables(skyline_app)


### PR DESCRIPTION
IssueID #4018: thunder - skyline.errors

- Added RedisErrorLogHandler to add agents

Modified:
skyline/analyzer/agent.py
skyline/analyzer/agent_batch.py
skyline/boundary/agent.py
skyline/crucible/agent.py
skyline/flux/logger.py
skyline/horizon/agent.py
skyline/ionosphere/agent.py
skyline/luminosity/agent.py
skyline/mirage/agent.py
skyline/panorama/agent.py
skyline/snab/agent.py
skyline/snab/snab_flux_load_test_agent.py
skyline/thunder/agent.py
skyline/vista/agent.py