### PR TITLE
v3.0.3 (2)

### DIFF
--- a/skyline/functions/metrics_manager/get_flux_namespaces.py
+++ b/skyline/functions/metrics_manager/get_flux_namespaces.py
@@ -59,7 +59,11 @@ def get_flux_namespaces(self):
                 last_timestamp = int(float(metrics_manager_flux_namespaces_dict[namespace]))
                 age = current_timestamp - last_timestamp
                 if age > 86400:
-                    logger.info('metrics_manager :: get_flux_namespaces :: removing %s from metrics_manager.flux.namespaces as no data for %s seconds' % str(age))
+                    # @modified 20220509 - Release #4560: v3.0.3
+                    #                      Feature #4536: Handle Redis failure
+                    # Added missing log str
+                    logger.info('metrics_manager :: get_flux_namespaces :: removing %s from metrics_manager.flux.namespaces as no data for %s seconds' % (
+                        str(namespace), str(age)))
                     remove_stale_namespaces.append(namespace)
             except Exception as err:
                 logger.error('error :: metrics_manager :: get_flux_namespaces :: failed to determine last data time for %s - %s' % (

--- a/skyline/luminosity/cloudburst.py
+++ b/skyline/luminosity/cloudburst.py
@@ -524,7 +524,7 @@ class Cloudburst(Thread):
                 if not timeseries:
                     # @modified 20220506 - Feature #4164: luminosity - cloudbursts
                     # Change error to warning
-                    logger.error('error :: cloudburst :: find_cloudbursts :: no timeseries from Graphite for %s' % base_name)
+                    # logger.error('error :: cloudburst :: find_cloudbursts :: no timeseries from Graphite for %s' % base_name)
                     logger.warning('warning :: cloudburst :: find_cloudbursts :: no timeseries from Graphite for %s' % base_name)
                     continue
 

--- a/skyline/luminosity/cloudbursts.py
+++ b/skyline/luminosity/cloudbursts.py
@@ -394,7 +394,7 @@ class Cloudbursts(Thread):
                 SERVER_METRIC_PATH = ''
         except Exception as e:
             SERVER_METRIC_PATH = ''
-            logger.warn('warning :: luminosity/cloudbursts :: settings.SERVER_METRICS_NAME is not declared in settings.py, defaults to \'\' - %s' % e)
+            logger.warning('warning :: luminosity/cloudbursts :: settings.SERVER_METRICS_NAME is not declared in settings.py, defaults to \'\' - %s' % e)
 
         while 1:
             now = time()


### PR DESCRIPTION
IssueID #4552: v3.0.3
IssueID #4164: luminosity - cloudbursts
IssueID #4536: Handle Redis failure

- Change error to warning for Graphite timeseries is unavailable (4164: luminosity - cloudbursts)
- Added missing log str (#4536: Handle Redis failure)

Modified:
skyline/functions/metrics_manager/get_flux_namespaces.py
skyline/luminosity/cloudburst.py
skyline/luminosity/cloudbursts.py