### PR TITLE
IssueID #4962: Build and test skyline v4.0.0

### DIFF
--- a/docs/readthedocs.requirements.txt
+++ b/docs/readthedocs.requirements.txt
@@ -17,7 +17,8 @@ pip>=10.0.1
 #Sphinx==5.3.0
 #sphinx-rtd-theme==1.1.1
 #recommonmark==0.7.1
-Sphinx==7.0.1
+#Sphinx==7.0.1  # sphinx-rtd-theme 1.2.2 depends on sphinx<7 and >=1.6
+Sphinx==6.2.1
 sphinx-rtd-theme==1.2.2
 recommonmark
 


### PR DESCRIPTION
IssueID #4974: v4.0.0

- More readthedocs build malarkey with Sphinx. Not Sphinx==7.0.1 because sphinx-rtd-theme 1.2.2 depends on sphinx<7 and >=1.6 so use Sphinx==6.2.1

Modified:
docs/readthedocs.requirements.txt