### PR TITLE
IssueID #4962: Build and test skyline v4.0.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2015-2022 Gary Wilson (@earthgecko)
+Copyright (c) 2015-2023 Gary Wilson (@earthgecko)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/readthedocs.requirements.txt
+++ b/docs/readthedocs.requirements.txt
@@ -50,7 +50,11 @@ hiredis==2.0.0
 # @modified 20230625 - Task #4962: Build and test skyline v4.0.0
 #                      Task #4778: v4.0.0 - update dependencies
 #docutils==0.18.1
-docutils==0.20.1
+# readthedocs error 
+# The user requested docutils==0.20.1
+# sphinx 6.2.1 depends on docutils<0.20 and >=0.18.1
+#docutils==0.20.1
+docutils==0.19
 
 lockfile==0.12.2
 # @modified 20211220 - Task #4344: Update dependencies


### PR DESCRIPTION
IssueID #4974: v4.0.0

- More readthedocs build malarkey with Sphinx. sphinx 6.2.1 depends on docutils<0.20 and >=0.18.1 so not docutils==0.20.1 use docutils==0.19
- Updated date in license

Modified:
LICENSE
docs/readthedocs.requirements.txt