### PR TITLE
Update getting-started.rst to fix installation link

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -1,7 +1,7 @@
 Getting started
 ===============
 
-.. _Installation: ../html/installation.html
+.. _Installation: ../latest/installation.html
 
 See the `Installation`_ page **after** reviewing the below.
 


### PR DESCRIPTION
Fix broken link in docs, replace /html/ with /latest/