### PR TITLE
custom_algorithms changes for v5.0.0

### DIFF
--- a/skyline/custom_algorithm_sources/sigma/sigma.py
+++ b/skyline/custom_algorithm_sources/sigma/sigma.py
@@ -546,6 +546,12 @@ def ks_test(current_skyline_app, X, Y, timeseries, second_order_resolution_secon
         if reference.size < 20 or probe.size < 20:
             return False
 
+        # @added 20250623 - Bug #5635: statsmodels - adfuller handle constant
+        #                   Bug #5593: statsmodels adfuller error in Analyzer
+        # Handle ValueError: Invalid input, x is constant
+        if np.all(reference == reference[0]):
+            return False
+
         ks_d, ks_p_value = scipy.stats.ks_2samp(reference, probe)
 
         if ks_p_value < 0.05 and ks_d > 0.5:

--- a/skyline/custom_algorithms/adtk_level_shift.py
+++ b/skyline/custom_algorithms/adtk_level_shift.py
@@ -57,7 +57,7 @@ def adtk_level_shift(current_skyline_app, parent_pid, timeseries, algorithm_para
     :param algorithm_parameters: a dictionary of any required parameters for the
         custom_algorithm and algorithm itself.  For the matrixprofile custom
         algorithm the following parameters are required, example:
-        Example usage:
+        Example usage::
         
             algorithm_parameters={
                 'anomaly_window': 1,
@@ -68,6 +68,7 @@ def adtk_level_shift(current_skyline_app, parent_pid, timeseries, algorithm_para
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -100,44 +101,45 @@ def adtk_level_shift(current_skyline_app, parent_pid, timeseries, algorithm_para
 
     UPDATE: 20241026 - under Python 3.10 the load time adtk algorithms alone
     is between 3 and 21.099188 seconds in lumnosity, depending how busy the box
-    is!
+    is!::
 
-    2021-03-06 10:46:38 :: 1582754 :: algorithm run count - histogram_bins run 567 times
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - histogram_bins has 567 timings
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timing - histogram_bins - total: 1.051136 - median: 0.001430
-    2021-03-06 10:46:38 :: 1582754 :: algorithm run count - first_hour_average run 567 times
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - first_hour_average has 567 timings
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timing - first_hour_average - total: 1.322432 - median: 0.001835
-    2021-03-06 10:46:38 :: 1582754 :: algorithm run count - stddev_from_average run 567 times
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - stddev_from_average has 567 timings
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timing - stddev_from_average - total: 1.097290 - median: 0.001641
-    2021-03-06 10:46:38 :: 1582754 :: algorithm run count - grubbs run 567 times
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - grubbs has 567 timings
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timing - grubbs - total: 1.742929 - median: 0.002438
-    2021-03-06 10:46:38 :: 1582754 :: algorithm run count - ks_test run 147 times
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - ks_test has 147 timings
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timing - ks_test - total: 0.127648 - median: 0.000529
-    2021-03-06 10:46:38 :: 1582754 :: algorithm run count - mean_subtraction_cumulation run 40 times
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - mean_subtraction_cumulation has 40 timings
-    2021-03-06 10:46:38 :: 1582754 :: algorithm timing - mean_subtraction_cumulation - total: 0.152515 - median: 0.003152
-    2021-03-06 10:46:39 :: 1582754 :: algorithm run count - median_absolute_deviation run 35 times
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - median_absolute_deviation has 35 timings
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timing - median_absolute_deviation - total: 0.143770 - median: 0.003248
-    2021-03-06 10:46:39 :: 1582754 :: algorithm run count - stddev_from_moving_average run 30 times
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - stddev_from_moving_average has 30 timings
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timing - stddev_from_moving_average - total: 0.125173 - median: 0.003092
-    2021-03-06 10:46:39 :: 1582754 :: algorithm run count - least_squares run 16 times
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - least_squares has 16 timings
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timing - least_squares - total: 0.089108 - median: 0.005538
-    2021-03-06 10:46:39 :: 1582754 :: algorithm run count - abs_stddev_from_median run 1 times
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - abs_stddev_from_median has 1 timings
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timing - abs_stddev_from_median - total: 0.036797 - median: 0.036797
-    2021-03-06 10:46:39 :: 1582754 :: algorithm run count - adtk_level_shift run 271 times
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - adtk_level_shift has 271 timings
-    2021-03-06 10:46:39 :: 1582754 :: algorithm timing - adtk_level_shift - total: 13.729565 - median: 0.035791
-    ...
-    ...
-    2021-03-06 10:46:39 :: 1582754 :: seconds to run     :: 27.93  # THE TOTAL ANALYZER RUNTIME
+        2021-03-06 10:46:38 :: 1582754 :: algorithm run count - histogram_bins run 567 times
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - histogram_bins has 567 timings
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timing - histogram_bins - total: 1.051136 - median: 0.001430
+        2021-03-06 10:46:38 :: 1582754 :: algorithm run count - first_hour_average run 567 times
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - first_hour_average has 567 timings
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timing - first_hour_average - total: 1.322432 - median: 0.001835
+        2021-03-06 10:46:38 :: 1582754 :: algorithm run count - stddev_from_average run 567 times
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - stddev_from_average has 567 timings
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timing - stddev_from_average - total: 1.097290 - median: 0.001641
+        2021-03-06 10:46:38 :: 1582754 :: algorithm run count - grubbs run 567 times
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - grubbs has 567 timings
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timing - grubbs - total: 1.742929 - median: 0.002438
+        2021-03-06 10:46:38 :: 1582754 :: algorithm run count - ks_test run 147 times
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - ks_test has 147 timings
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timing - ks_test - total: 0.127648 - median: 0.000529
+        2021-03-06 10:46:38 :: 1582754 :: algorithm run count - mean_subtraction_cumulation run 40 times
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timings count - mean_subtraction_cumulation has 40 timings
+        2021-03-06 10:46:38 :: 1582754 :: algorithm timing - mean_subtraction_cumulation - total: 0.152515 - median: 0.003152
+        2021-03-06 10:46:39 :: 1582754 :: algorithm run count - median_absolute_deviation run 35 times
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - median_absolute_deviation has 35 timings
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timing - median_absolute_deviation - total: 0.143770 - median: 0.003248
+        2021-03-06 10:46:39 :: 1582754 :: algorithm run count - stddev_from_moving_average run 30 times
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - stddev_from_moving_average has 30 timings
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timing - stddev_from_moving_average - total: 0.125173 - median: 0.003092
+        2021-03-06 10:46:39 :: 1582754 :: algorithm run count - least_squares run 16 times
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - least_squares has 16 timings
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timing - least_squares - total: 0.089108 - median: 0.005538
+        2021-03-06 10:46:39 :: 1582754 :: algorithm run count - abs_stddev_from_median run 1 times
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - abs_stddev_from_median has 1 timings
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timing - abs_stddev_from_median - total: 0.036797 - median: 0.036797
+        2021-03-06 10:46:39 :: 1582754 :: algorithm run count - adtk_level_shift run 271 times
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timings count - adtk_level_shift has 271 timings
+        2021-03-06 10:46:39 :: 1582754 :: algorithm timing - adtk_level_shift - total: 13.729565 - median: 0.035791
+        ...
+        ...
+        2021-03-06 10:46:39 :: 1582754 :: seconds to run     :: 27.93  # THE TOTAL ANALYZER RUNTIME
+
 
     Therefore the analysis methodology implemented for the adtk_level_shift
     custom_algorithm is as folows:
@@ -176,22 +178,23 @@ def adtk_level_shift(current_skyline_app, parent_pid, timeseries, algorithm_para
 
     Example CUSTOM_ALGORITHMS configuration::
 
-    'adtk_level_shift': {
-        'namespaces': [
-            'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
-            'skyline.analyzer.exceptions'
-        ],
-        'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_level_shift.py',
-        'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both', 'window': 5},
-        'max_execution_time': 0.5,
-        'consensus': 1,
-        'algorithms_allowed_in_consensus': ['adtk_level_shift'],
-        'run_3sigma_algorithms': True,
-        'run_before_3sigma': True,
-        'run_only_if_consensus': False,
-        'use_with': ["analyzer", "mirage"],
-        'debug_logging': False,
-    },
+        'adtk_level_shift': {
+            'namespaces': [
+                'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
+                'skyline.analyzer.exceptions'
+            ],
+            'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_level_shift.py',
+            'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both', 'window': 5},
+            'max_execution_time': 0.5,
+            'consensus': 1,
+            'algorithms_allowed_in_consensus': ['adtk_level_shift'],
+            'run_3sigma_algorithms': True,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
+            'use_with': ["analyzer", "mirage"],
+            'debug_logging': False,
+        },
+
 
     """
 
@@ -773,7 +776,18 @@ def adtk_level_shift(current_skyline_app, parent_pid, timeseries, algorithm_para
                     algorithm_name, str(len(anomalies))))
 
             if len(anomalies) > 0:
-                anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                # @modified 20260224 - Task #5628: Build v5.0.0 and test
+                #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+                #                      Task #5526: Build v5.0.0 and upgrade deps
+                #                      Task #5627: v5.0.0 update dependencies
+                # Handle pandas deprecation which results in all timestamps being
+                # returned as 1.  From pandas changelog:
+                # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+                # Disallow passing a pandas type to Index.view() (GH 55709)
+                # https://github.com/pandas-dev/pandas/issues/55709
+                #anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                anomaly_timestamps = [int(ts.value // 10**9) for ts in anomalies.index]
+
                 if realtime_analysis:
                     last_window_timestamps = [int(item[0]) for item in timeseries[-window:]]
                     # if timeseries[-1][0] in anomaly_timestamps:
@@ -932,7 +946,18 @@ def adtk_level_shift(current_skyline_app, parent_pid, timeseries, algorithm_para
                         current_logger.info('%s :: %s anomalies found with PersistAD on %s' % (
                             algorithm_name, str(len(persist_ad_anomalies)),
                             base_name))
-                        persist_ad_anomaly_timestamps = list(persist_ad_anomalies.index.astype(np.int64) // 10**9)
+                        # @modified 20260224 - Task #5628: Build v5.0.0 and test
+                        #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+                        #                      Task #5526: Build v5.0.0 and upgrade deps
+                        #                      Task #5627: v5.0.0 update dependencies
+                        # Handle pandas deprecation which results in all timestamps being
+                        # returned as 1.  From pandas changelog:
+                        # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+                        # Disallow passing a pandas type to Index.view() (GH 55709)
+                        # https://github.com/pandas-dev/pandas/issues/55709
+                        #persist_ad_anomaly_timestamps = list(persist_ad_anomalies.index.astype(np.int64) // 10**9)
+                        persist_ad_anomaly_timestamps = [int(ts.value // 10**9) for ts in persist_ad_anomalies.index]
+
                         # Convert persist_ad_anomalies dataframe to persist_ad_anomalies_list
                         persist_ad_anomalies_list = []
                         persist_ad_anomalies_dict = {}

--- a/skyline/custom_algorithms/adtk_persist.py
+++ b/skyline/custom_algorithms/adtk_persist.py
@@ -56,13 +56,16 @@ def adtk_persist(current_skyline_app, parent_pid, timeseries, algorithm_paramete
         [1578920400.0, 55.0], ... [1580353200.0, 55.0]]``
     :param algorithm_parameters: a dictionary of any required parameters for the
         custom_algorithm and algorithm itself.  For the matrixprofile custom
-        algorithm the following parameters are required, example:
-        ``algorithm_parameters={
-            'c': 9.0,
-            'run_every': 5,
-            'side': 'both',
-            'window': 5
-        }``
+        algorithm the following parameters are required, example::
+
+            algorithm_parameters={
+                'c': 9.0,
+                'run_every': 5,
+                'side': 'both',
+                'window': 5
+            }
+
+
     :type current_skyline_app: str
     :type parent_pid: int
     :type timeseries: list
@@ -125,25 +128,24 @@ def adtk_persist(current_skyline_app, parent_pid, timeseries, algorithm_paramete
     For metrics with a different resolution/frequency may require different
     values appropriate for metric resolution.
 
-    :
-    Example CUSTOM_ALGORITHMS configuration:
+    Example CUSTOM_ALGORITHMS configuration::
 
-    'adtk_persist': {
-        'namespaces': [
-            'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
-            'skyline.analyzer.exceptions'
-        ],
-        'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_persist.py',
-        'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both', 'window': 5},
-        'max_execution_time': 0.5,
-        'consensus': 1,
-        'algorithms_allowed_in_consensus': ['adtk_persist'],
-        'run_3sigma_algorithms': True,
-        'run_before_3sigma': True,
-        'run_only_if_consensus': False,
-        'use_with': ["analyzer", "mirage"],
-        'debug_logging': False,
-    },
+        'adtk_persist': {
+            'namespaces': [
+                'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
+                'skyline.analyzer.exceptions'
+            ],
+            'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_persist.py',
+            'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both', 'window': 5},
+            'max_execution_time': 0.5,
+            'consensus': 1,
+            'algorithms_allowed_in_consensus': ['adtk_persist'],
+            'run_3sigma_algorithms': True,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
+            'use_with': ["analyzer", "mirage"],
+            'debug_logging': False,
+        },
 
     """
 
@@ -727,7 +729,18 @@ def adtk_persist(current_skyline_app, parent_pid, timeseries, algorithm_paramete
                     algorithm_name, str(len(anomalies))))
 
             if len(anomalies) > 0:
-                anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                # @modified 20260224 - Task #5628: Build v5.0.0 and test
+                #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+                #                      Task #5526: Build v5.0.0 and upgrade deps
+                #                      Task #5627: v5.0.0 update dependencies
+                # Handle pandas deprecation which results in all timestamps being
+                # returned as 1.  From pandas changelog:
+                # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+                # Disallow passing a pandas type to Index.view() (GH 55709)
+                # https://github.com/pandas-dev/pandas/issues/55709
+                #anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                anomaly_timestamps = [int(ts.value // 10**9) for ts in anomalies.index]
+
                 if realtime_analysis:
                     last_window_timestamps = [int(item[0]) for item in timeseries[-window:]]
                     # if timeseries[-1][0] in anomaly_timestamps:

--- a/skyline/custom_algorithms/adtk_seasonal.py
+++ b/skyline/custom_algorithms/adtk_seasonal.py
@@ -56,12 +56,15 @@ def adtk_seasonal(current_skyline_app, parent_pid, timeseries, algorithm_paramet
         [1578920400.0, 55.0], ... [1580353200.0, 55.0]]``
     :param algorithm_parameters: a dictionary of any required parameters for the
         custom_algorithm and algorithm itself.  For the matrixprofile custom
-        algorithm the following parameters are required, example:
-        ``algorithm_parameters={
-            'c': 9.0,
-            'run_every': 5,
-            'side': 'both',
-        }``
+        algorithm the following parameters are required, example::
+
+            algorithm_parameters={
+                'c': 9.0,
+                'run_every': 5,
+                'side': 'both',
+            }
+
+
     :type current_skyline_app: str
     :type parent_pid: int
     :type timeseries: list
@@ -125,24 +128,25 @@ def adtk_seasonal(current_skyline_app, parent_pid, timeseries, algorithm_paramet
     values appropriate for metric resolution.
 
     :
-    Example CUSTOM_ALGORITHMS configuration:
+    Example CUSTOM_ALGORITHMS configuration::
 
-    'adtk_seasonal': {
-        'namespaces': [
-            'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
-            'skyline.analyzer.exceptions'
-        ],
-        'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_seasonal.py',
-        'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both'},
-        'max_execution_time': 0.5,
-        'consensus': 1,
-        'algorithms_allowed_in_consensus': ['adtk_seasonal'],
-        'run_3sigma_algorithms': True,
-        'run_before_3sigma': True,
-        'run_only_if_consensus': False,
-        'use_with': ["analyzer", "mirage"],
-        'debug_logging': False,
-    },
+        'adtk_seasonal': {
+            'namespaces': [
+                'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
+                'skyline.analyzer.exceptions'
+            ],
+            'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_seasonal.py',
+            'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both'},
+            'max_execution_time': 0.5,
+            'consensus': 1,
+            'algorithms_allowed_in_consensus': ['adtk_seasonal'],
+            'run_3sigma_algorithms': True,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
+            'use_with': ["analyzer", "mirage"],
+            'debug_logging': False,
+        },
+
 
     """
 
@@ -733,7 +737,18 @@ def adtk_seasonal(current_skyline_app, parent_pid, timeseries, algorithm_paramet
                     algorithm_name, str(len(anomalies))))
 
             if len(anomalies) > 0:
-                anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                # @modified 20260224 - Task #5628: Build v5.0.0 and test
+                #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+                #                      Task #5526: Build v5.0.0 and upgrade deps
+                #                      Task #5627: v5.0.0 update dependencies
+                # Handle pandas deprecation which results in all timestamps being
+                # returned as 1.  From pandas changelog:
+                # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+                # Disallow passing a pandas type to Index.view() (GH 55709)
+                # https://github.com/pandas-dev/pandas/issues/55709
+                #anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                anomaly_timestamps = [int(ts.value // 10**9) for ts in anomalies.index]
+
                 if realtime_analysis:
                     last_window_timestamps = [int(item[0]) for item in timeseries[-window:]]
                     # if timeseries[-1][0] in anomaly_timestamps:

--- a/skyline/custom_algorithms/adtk_volatility_shift.py
+++ b/skyline/custom_algorithms/adtk_volatility_shift.py
@@ -56,13 +56,16 @@ def adtk_volatility_shift(current_skyline_app, parent_pid, timeseries, algorithm
         [1578920400.0, 55.0], ... [1580353200.0, 55.0]]``
     :param algorithm_parameters: a dictionary of any required parameters for the
         custom_algorithm and algorithm itself.  For the matrixprofile custom
-        algorithm the following parameters are required, example:
-        ``algorithm_parameters={
-            'c': 9.0,
-            'run_every': 5,
-            'side': 'both',
-            'window': 5
-        }``
+        algorithm the following parameters are required, example::
+
+            algorithm_parameters={
+                'c': 9.0,
+                'run_every': 5,
+                'side': 'both',
+                'window': 5
+            }
+
+
     :type current_skyline_app: str
     :type parent_pid: int
     :type timeseries: list
@@ -125,25 +128,25 @@ def adtk_volatility_shift(current_skyline_app, parent_pid, timeseries, algorithm
     For metrics with a different resolution/frequency may require different
     values appropriate for metric resolution.
 
-    :
-    Example CUSTOM_ALGORITHMS configuration:
+    Example CUSTOM_ALGORITHMS configuration::
 
-    'adtk_volatility_shift': {
-        'namespaces': [
-            'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
-            'skyline.analyzer.exceptions'
-        ],
-        'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_volatility_shift.py',
-        'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both', 'window': 5},
-        'max_execution_time': 0.5,
-        'consensus': 1,
-        'algorithms_allowed_in_consensus': ['adtk_volatility_shift'],
-        'run_3sigma_algorithms': True,
-        'run_before_3sigma': True,
-        'run_only_if_consensus': False,
-        'use_with': ["analyzer", "mirage"],
-        'debug_logging': False,
-    },
+        'adtk_volatility_shift': {
+            'namespaces': [
+                'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
+                'skyline.analyzer.exceptions'
+            ],
+            'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/adtk_volatility_shift.py',
+            'algorithm_parameters': {'c': 9.0, 'run_every': 5, 'side': 'both', 'window': 5},
+            'max_execution_time': 0.5,
+            'consensus': 1,
+            'algorithms_allowed_in_consensus': ['adtk_volatility_shift'],
+            'run_3sigma_algorithms': True,
+            'run_before_3sigma': True,
+            'run_only_if_consensus': False,
+            'use_with': ["analyzer", "mirage"],
+            'debug_logging': False,
+        },
+
 
     """
 
@@ -726,7 +729,18 @@ def adtk_volatility_shift(current_skyline_app, parent_pid, timeseries, algorithm
                     algorithm_name, str(len(anomalies))))
 
             if len(anomalies) > 0:
-                anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                # @modified 20260224 - Task #5628: Build v5.0.0 and test
+                #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+                #                      Task #5526: Build v5.0.0 and upgrade deps
+                #                      Task #5627: v5.0.0 update dependencies
+                # Handle pandas deprecation which results in all timestamps being
+                # returned as 1.  From pandas changelog:
+                # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+                # Disallow passing a pandas type to Index.view() (GH 55709)
+                # https://github.com/pandas-dev/pandas/issues/55709
+                #anomaly_timestamps = list(anomalies.index.astype(np.int64) // 10**9)
+                anomaly_timestamps = [int(ts.value // 10**9) for ts in anomalies.index]
+
                 if realtime_analysis:
                     last_window_timestamps = [int(item[0]) for item in timeseries[-window:]]
                     # if timeseries[-1][0] in anomaly_timestamps:

--- a/skyline/custom_algorithms/anomalous_daily_peak.py
+++ b/skyline/custom_algorithms/anomalous_daily_peak.py
@@ -450,11 +450,17 @@ def anomalous_daily_peak(current_skyline_app, parent_pid, timeseries, algorithm_
 
         # Determine the mean and stdDev of the sums of each peak period (excl
         # the anomalous peak period)
-        peak_values_mean = np.mean(peak_values)
-        peak_values_stdDev = np.std(peak_values)
+        # @modified 20260430 - Feature #5519: functions.skyline.coerce_to_valid_json
+        #                      Bug #5518: custom_algorithms_results - invalid JSON
+        # Wrapped in float to coerce np.float64
+        peak_values_mean = float(np.mean(peak_values))
+        peak_values_stdDev = float(np.std(peak_values))
 
-        peak_difference = anomaly_peak_values_sum - peak_values_mean
-        threesigma3_peak_values_stdDev = 3 * peak_values_stdDev
+        # @modified 20260430 - Feature #5519: functions.skyline.coerce_to_valid_json
+        #                      Bug #5518: custom_algorithms_results - invalid JSON
+        # Wrapped in float to coerce np.float64
+        peak_difference = float(anomaly_peak_values_sum - peak_values_mean)
+        threesigma3_peak_values_stdDev = float(3 * peak_values_stdDev)
 
         if anomaly_peak_values_sum == 0:
             debug_dict = {
@@ -487,6 +493,17 @@ def anomalous_daily_peak(current_skyline_app, parent_pid, timeseries, algorithm_
         # the overhead of importing numpy here just to load the type
         if type(anomalous) is not None and type(anomalous).__name__ == 'bool_':
             anomalous = bool(anomalous)
+
+        # @added 20260430 - Feature #5519: functions.skyline.coerce_to_valid_json
+        #                   Bug #5518: custom_algorithms_results - invalid JSON
+        # Coerce np.bool
+        # Handle np.True_ and np.False_ which evaluate to True and False when
+        # evaluated as a str
+        anomalous_str = str(anomalous)
+        if anomalous_str == 'True':
+            anomalous = True
+        if anomalous_str == 'False':
+            anomalous = False
 
         percent_different = 0
         if within_percent_of_normal_peaks and anomalous:

--- a/skyline/custom_algorithms/azure_ai_anomalydetector.py
+++ b/skyline/custom_algorithms/azure_ai_anomalydetector.py
@@ -76,7 +76,7 @@ def azure_ai_anomalydetector(current_skyline_app, parent_pid, timeseries, algori
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
+        Example usage::
         
             algorithm_parameters={
                 'anomaly_window': 1,
@@ -85,6 +85,7 @@ def azure_ai_anomalydetector(current_skyline_app, parent_pid, timeseries, algori
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int

--- a/skyline/custom_algorithms/dbscan.py
+++ b/skyline/custom_algorithms/dbscan.py
@@ -106,8 +106,9 @@ def dbscan(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'window': 3,
@@ -118,6 +119,7 @@ def dbscan(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -137,7 +139,13 @@ def dbscan(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/grafana_promql_anomaly_detection.py
+++ b/skyline/custom_algorithms/grafana_promql_anomaly_detection.py
@@ -99,8 +99,8 @@ def grafana_promql_anomaly_detection(current_skyline_app, parent_pid, timeseries
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'min_anomaly_duration_seconds': 300,
@@ -113,6 +113,7 @@ def grafana_promql_anomaly_detection(current_skyline_app, parent_pid, timeseries
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -132,7 +133,14 @@ def grafana_promql_anomaly_detection(current_skyline_app, parent_pid, timeseries
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {'preprocessing': {}, 'timings': {}}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores,
+        'preprocessing': {}, 'timings': {}
+    }
 
     current_logger = None
 
@@ -332,6 +340,10 @@ def grafana_promql_anomaly_detection(current_skyline_app, parent_pid, timeseries
         T = '%sT' % str(data_points_per_period)
         # Just be opinionated and set
         T = '10T'
+        # @added 20260227 - Task #5628: Build v5.0.0 and test
+        # changed T to min as per warning in pandas 2.2.3
+        T = '10min'
+
         # Resampling is done on the median to ensure more robustness to
         # outliers, unless there is very little variance in the data and
         # then median can result in all values being 0, a check is done.
@@ -345,7 +357,18 @@ def grafana_promql_anomaly_detection(current_skyline_app, parent_pid, timeseries
             mean_resampled_df = df.resample(T, origin='end').mean().bfill()
             resampled_df = mean_resampled_df.copy()
             mean_resampled_values = mean_resampled_df['value'].to_numpy().tolist()
-            mean_resampled_df['ts'] = mean_resampled_df.index.astype(np.int64) // 10**9
+            # @modified 20260224 - Task #5628: Build v5.0.0 and test
+            #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+            #                      Task #5526: Build v5.0.0 and upgrade deps
+            #                      Task #5627: v5.0.0 update dependencies
+            # Handle pandas deprecation which results in all timestamps being
+            # returned as 1.  From pandas changelog:
+            # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+            # Disallow passing a pandas type to Index.view() (GH 55709)
+            # https://github.com/pandas-dev/pandas/issues/55709
+            #mean_resampled_df['ts'] = mean_resampled_df.index.astype(np.int64) // 10**9
+            mean_resampled_df['ts'] = [int(ts.value // 10**9) for ts in mean_resampled_df.index]
+
             if print_debug:
                 print('resampled on mean because median resample was 0s or low_variance: %s' % str(normalised_var))
             if debug_logging:
@@ -353,7 +376,17 @@ def grafana_promql_anomaly_detection(current_skyline_app, parent_pid, timeseries
             mean_resampled_timestamps = mean_resampled_df['ts'].to_numpy().tolist()
             mean_resampled_timeseries = [[t, mean_resampled_values[index]] for index, t in enumerate(mean_resampled_timestamps)]
         resampled_ts_df = resampled_df.copy()
-        resampled_ts_df['ts'] = resampled_ts_df.index.astype(np.int64) // 10**9
+        # @modified 20260224 - Task #5628: Build v5.0.0 and test
+        #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+        #                      Task #5526: Build v5.0.0 and upgrade deps
+        #                      Task #5627: v5.0.0 update dependencies
+        # Handle pandas deprecation which results in all timestamps being
+        # returned as 1.  From pandas changelog:
+        # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+        # Disallow passing a pandas type to Index.view() (GH 55709)
+        # https://github.com/pandas-dev/pandas/issues/55709
+        #resampled_ts_df['ts'] = resampled_ts_df.index.astype(np.int64) // 10**9
+        resampled_ts_df['ts'] = [int(ts.value // 10**9) for ts in resampled_ts_df.index]
 
         resampled_timestamps = resampled_ts_df['ts'].to_numpy().tolist()
         resampled_timeseries = [[t, resampled_values[index]] for index, t in enumerate(resampled_timestamps)]

--- a/skyline/custom_algorithms/irregular_unstable.py
+++ b/skyline/custom_algorithms/irregular_unstable.py
@@ -116,7 +116,11 @@ def irregular_unstable(current_skyline_app, parent_pid, timeseries, algorithm_pa
             np_max = np.amax(np_values)
             np_min = np.amin(np_values)
             norm_np_values = (np_values - np_min) / (np_max - np_min)
-            normalised_var = round(np.var(norm_np_values), 4)
+            # @modified 20251019 - Feature #5519: functions.skyline.coerce_to_valid_json
+            #                      Bug #5518: custom_algorithms_results - invalid JSON
+            # Wrapped in float to prevent
+            #'normalised_var_7d': np.float64(0.0058), 'normalised_var_30d': np.float64(0.0687)
+            normalised_var = float(round(np.var(norm_np_values), 4))
         except:
             normalised_var = np.nan
         return normalised_var
@@ -262,7 +266,10 @@ def irregular_unstable(current_skyline_app, parent_pid, timeseries, algorithm_pa
             np_timestamps = np.array(timestamps)
             ts_diffs = np.diff(np_timestamps)
             resolution_counts = np.unique(ts_diffs, return_counts=True)
-            resolution = resolution_counts[0][np.argmax(resolution_counts[1])]
+            # @modified 20251019 - Feature #5519: functions.skyline.coerce_to_valid_json
+            #                      Bug #5518: custom_algorithms_results - invalid JSON
+            # Wrapped in float to prevent
+            resolution = float(resolution_counts[0][np.argmax(resolution_counts[1])])
             if resolution > 900:
                 # Not suited to low resolution data
 

--- a/skyline/custom_algorithms/isolation_forest.py
+++ b/skyline/custom_algorithms/isolation_forest.py
@@ -30,7 +30,11 @@ from sklearn.ensemble import IsolationForest
 def isolation_forest(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
 
     """
-    Outlier detector based on Isolation Forest.
+    Outlier detector based on scikit-learn Isolation Forest.
+
+    See sklearn.ensemble.IsolationForest for full implementation details and
+    in-depth details regarding the parameters -
+    https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.IsolationForest.html
 
     :param current_skyline_app: the Skyline app executing the algorithm.  This
         will be passed to the algorithm by Skyline.  This is **required** for
@@ -53,7 +57,6 @@ def isolation_forest(current_skyline_app, parent_pid, timeseries, algorithm_para
             when determining if the metric is anomalous. Only the last
             ``anomaly_window`` data points in the time series will be used to
             determine if the metric is anomalous.  Default is ``1``.
-        - ``'contamination'`` (float):
         - ``'contamination'`` (float or "auto"):
             The proportion of the dataset that is expected to be anomalies or
             outliers. This can be either:
@@ -65,7 +68,8 @@ def isolation_forest(current_skyline_app, parent_pid, timeseries, algorithm_para
             - The string ``"auto"``: This option allows the algorithm to 
                 automatically determine an appropriate contamination level based
                 on the characteristics of the data. Useful when the proportion
-                of outliers is unknown.
+                of outliers is unknown.  The threshold is determined as in the
+                original paper [1]_.
             Default is ``"auto"``.
          - ``'return_results'`` (bool): Optional.
             If ``True``, returns the results dict in addition to anomalous and
@@ -76,14 +80,36 @@ def isolation_forest(current_skyline_app, parent_pid, timeseries, algorithm_para
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        References:
+
+        .. [1] F. T. Liu, K. M. Ting and Z. -H. Zhou.
+            :doi:`"Isolation forest." <10.1109/ICDM.2008.17>`
+            2008 Eighth IEEE International Conference on Data Mining (ICDM),
+            2008, pp. 413-422.
+
+        Example usage::
+
+            # Setting contamination to classify 1% of the data outliers/anomalies
+            # a making a decision based on the last data point, anomaly_window 1
+            # Running in a realtime in Mirage you want to set the anomaly_window
+            # to 1 and contamination to either 0.01 or "auto".
             algorithm_parameters={
                 'anomaly_window': 1,
-                'contamination': 0.01,,
+                'contamination': 0.01,
                 'debug_logging': True,
                 'return_results': True,
             }
+
+            # Setting contamination to auto and determine any anomalies in the
+            # last 1008 data points.  This suits adhoc analysis on an entire
+            # data via Vortex 
+            algorithm_parameters={
+                'anomaly_window': 1008,
+                'contamination': 'auto',
+                'debug_logging': True,
+                'return_results': True,
+            }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -103,7 +129,13 @@ def isolation_forest(current_skyline_app, parent_pid, timeseries, algorithm_para
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/lad.py
+++ b/skyline/custom_algorithms/lad.py
@@ -73,14 +73,16 @@ def lad(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'threshold': 99,
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -100,7 +102,13 @@ def lad(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/laoccfdlpnc.py
+++ b/skyline/custom_algorithms/laoccfdlpnc.py
@@ -124,8 +124,8 @@ def laoccfdlpnc(current_skyline_app, parent_pid, timeseries, algorithm_parameter
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'oc_svm_nu': 0.05,
@@ -134,6 +134,7 @@ def laoccfdlpnc(current_skyline_app, parent_pid, timeseries, algorithm_parameter
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -153,7 +154,13 @@ def laoccfdlpnc(current_skyline_app, parent_pid, timeseries, algorithm_parameter
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
     timings = {}
 
     current_logger = None

--- a/skyline/custom_algorithms/lof.py
+++ b/skyline/custom_algorithms/lof.py
@@ -62,14 +62,15 @@ def lof(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 5,
                 'n_neighbors': 2,
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -89,7 +90,13 @@ def lof(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/low_variance_anomalous_peak_trough.py
+++ b/skyline/custom_algorithms/low_variance_anomalous_peak_trough.py
@@ -78,14 +78,15 @@ def low_variance_anomalous_peak_trough(current_skyline_app, parent_pid, timeseri
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 4,
                 'currently_anomalous': True,
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int

--- a/skyline/custom_algorithms/m66.py
+++ b/skyline/custom_algorithms/m66.py
@@ -85,8 +85,8 @@ def m66(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'nth_median': 6,
@@ -95,7 +95,8 @@ def m66(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
                 'debug_logging': True,
                 'return_results': True,
             }
-        
+
+
     :type current_skyline_app: str
     :type parent_pid: int
     :type timeseries: list
@@ -103,30 +104,31 @@ def m66(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     :return: anomalous, anomalyScore, results
     :rtype: tuple(bool, float, dict)
 
-    Example CUSTOM_ALGORITHMS configuration:
+    Example CUSTOM_ALGORITHMS configuration::
 
-    'm66': {
-        'namespaces': [
-            'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
-            'skyline.analyzer.exceptions'
-        ],
-        'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/m66.py',
-        'algorithm_parameters': {
-            'nth_median': 6, 'sigma': 6, 'window': 5, 'resolution': 60,
-            'minimum_sparsity': 0, 'determine_duration': False,
-            'return_anomalies': True, 'save_plots_to': False,
-            'save_plots_to_absolute_dir': False, 'filename_prefix': False,
-            'return_results': False, 'anomaly_window': 1,
+        'm66': {
+            'namespaces': [
+                'skyline.analyzer.run_time', 'skyline.analyzer.total_metrics',
+                'skyline.analyzer.exceptions'
+            ],
+            'algorithm_source': '/opt/skyline/github/skyline/skyline/custom_algorithms/m66.py',
+            'algorithm_parameters': {
+                'nth_median': 6, 'sigma': 6, 'window': 5, 'resolution': 60,
+                'minimum_sparsity': 0, 'determine_duration': False,
+                'return_anomalies': True, 'save_plots_to': False,
+                'save_plots_to_absolute_dir': False, 'filename_prefix': False,
+                'return_results': False, 'anomaly_window': 1,
+            },
+            'max_execution_time': 1.0
+            'consensus': 1,
+            'algorithms_allowed_in_consensus': ['m66'],
+            'run_3sigma_algorithms': False,
+            'run_before_3sigma': False,
+            'run_only_if_consensus': False,
+            'use_with': ['crucible', 'luminosity'],
+            'debug_logging': False,
         },
-        'max_execution_time': 1.0
-        'consensus': 1,
-        'algorithms_allowed_in_consensus': ['m66'],
-        'run_3sigma_algorithms': False,
-        'run_before_3sigma': False,
-        'run_only_if_consensus': False,
-        'use_with': ['crucible', 'luminosity'],
-        'debug_logging': False,
-    },
+
 
     The context that you wish to use the algorithm in determines whether
     you should set return_anomalies to True or return_results to True or
@@ -135,6 +137,7 @@ def m66(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     anomalies if the return_anomalies was set to True, however for the
     inclusion as an algorithm that can be used in Vortex, it needed to
     be extended to be able to return a results dict.
+
     """
 
     # You MUST define the algorithm_name

--- a/skyline/custom_algorithms/macd.py
+++ b/skyline/custom_algorithms/macd.py
@@ -71,8 +71,8 @@ def macd(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'fast_window': 12,
@@ -82,6 +82,7 @@ def macd(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -101,7 +102,13 @@ def macd(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/mmzrmp.py
+++ b/skyline/custom_algorithms/mmzrmp.py
@@ -91,13 +91,14 @@ def mmzrmp(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -120,7 +121,10 @@ def mmzrmp(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     anomalies = {}
     anomalyScore_list = []
     scores = []
-    results = {'anomalous': anomalous, 'anomalies': anomalies, 'anomalyScore_list': anomalyScore_list, 'scores': scores}
+    results = {
+        'anomalous': anomalous, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores
+    }
 
     timings = {'algorithms': {}}
 

--- a/skyline/custom_algorithms/mstl.py
+++ b/skyline/custom_algorithms/mstl.py
@@ -77,8 +77,8 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'level': 99,
@@ -87,6 +87,7 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -108,7 +109,13 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores, 'results': {}
+    }
 
     current_logger = None
 
@@ -273,7 +280,7 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
         # `df` argument to the corresponding method instead, e.g. fit/forecast.
         quick_sf = StatsForecast(
             # df=df[-60:],
-            df=df[-60:],
+            #df=df[-60:],
             models=models, 
             freq=freq_str, 
             n_jobs=2,
@@ -290,7 +297,11 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
         quick_sf_df = df[-60:].copy()
         quick_sf.fit(df=quick_sf_df)
 
-        quick_fcst = quick_sf.forecast(h=horizon, level=levels, fitted=True)
+        # @modified 20251029 - Feature #4896: custom_algorithms - mstl
+        # Provide the `df` argument to the corresponding method
+        #quick_fcst = quick_sf.forecast(h=horizon, level=levels, fitted=True)
+        quick_fcst = quick_sf.forecast(df=quick_sf_df, h=horizon, level=levels, fitted=True)
+
         if debug_logging:
             current_logger.debug('debug :: mstl :: calculated quick_fcst for %s' % (base_name))
         # @modified 20241122 - Feature #4896: custom_algorithms - mstl
@@ -316,7 +327,10 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
         sf_df = df.copy()
         sf.fit(df=sf_df)
 
-        fcst = sf.forecast(h=horizon, level=levels, fitted=True)
+        # @modified 20251029 - Feature #4896: custom_algorithms - mstl
+        # Provide the `df` argument to the corresponding method
+        #fcst = sf.forecast(h=horizon, level=levels, fitted=True)
+        fcst = sf.forecast(df=sf_df, h=horizon, level=levels, fitted=True)
         if debug_logging:
             current_logger.debug('debug :: mstl :: calculated fcst for %s' % (base_name))
 
@@ -328,15 +342,32 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
         anomalies = insample_forecasts.loc[(insample_forecasts['y'] >= insample_forecasts[hi_column]) | (insample_forecasts['y'] <= insample_forecasts[lo_column])]
 
         aa_insample_forecasts = insample_forecasts.copy()
-        aa_insample_forecasts['ds'] = pd.to_datetime(aa_insample_forecasts['ds']).astype(int) / 10**9
+        # @modified 20260224 - Task #5628: Build v5.0.0 and test
+        #                      Task #5710: utcfromtimestamp - deprecated datetime and pandas
+        #                      Task #5526: Build v5.0.0 and upgrade deps
+        #                      Task #5627: v5.0.0 update dependencies
+        # Handle pandas deprecation which results in all timestamps being
+        # returned as 1.  From pandas changelog:
+        # https://pandas.pydata.org/docs/whatsnew/v3.0.0.html#whatsnew-300-prior-deprecations
+        # Disallow passing a pandas type to Index.view() (GH 55709)
+        # https://github.com/pandas-dev/pandas/issues/55709
+        #aa_insample_forecasts['ds'] = pd.to_datetime(aa_insample_forecasts['ds']).astype(int) / 10**9
+        aa_insample_forecasts['ds'] = pd.to_datetime(aa_insample_forecasts['ds']).map(lambda x: x.value / 10**9)
+
         aa_anomalies = anomalies.copy()
-        aa_anomalies['ds'] = pd.to_datetime(aa_anomalies['ds']).astype(int) / 10**9
+        # @modified 20260224 - Task #5710: utcfromtimestamp - deprecated datetime and pandas
+        #aa_anomalies['ds'] = pd.to_datetime(aa_anomalies['ds']).astype(int) / 10**9
+        aa_anomalies['ds'] = pd.to_datetime(aa_anomalies['ds']).map(lambda x: x.value / 10**9)
+
         timestamps = [int(t) for t in aa_insample_forecasts['ds'].tolist()]
         values = [float(v) for v in aa_insample_forecasts['y'].tolist()]
         anomaly_timestamps = [int(t) for t in aa_anomalies['ds'].tolist()]
         anomaly_values = aa_anomalies['y'].tolist()
         aa_insample_forecasts = insample_forecasts.copy()
-        aa_insample_forecasts['ds'] = pd.to_datetime(aa_insample_forecasts['ds']).astype(int) / 10**9
+        # @modified 20260224 - Task #5710: utcfromtimestamp - deprecated datetime and pandas
+        #aa_insample_forecasts['ds'] = pd.to_datetime(aa_insample_forecasts['ds']).astype(int) / 10**9
+        aa_insample_forecasts['ds'] = pd.to_datetime(aa_insample_forecasts['ds']).map(lambda x: x.value / 10**9)
+
         aa_insample_forecasts_timestamps = [int(t) for t in aa_insample_forecasts['ds'].tolist()]
         values = [float(v) for v in aa_insample_forecasts['y'].tolist()]
         if debug_logging:
@@ -392,7 +423,7 @@ def mstl(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
         record_algorithm_error(current_skyline_app, parent_pid, algorithm_name, traceback.format_exc())
         # Return None and None as the algorithm could not determine True or False
         if return_results:
-            return (None, None, None)
+            return (None, None, results)
         return (None, None)
 
     if return_results:

--- a/skyline/custom_algorithms/one_class_svm.py
+++ b/skyline/custom_algorithms/one_class_svm.py
@@ -79,8 +79,8 @@ def one_class_svm(current_skyline_app, parent_pid, timeseries, algorithm_paramet
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'window': 3,
@@ -89,6 +89,7 @@ def one_class_svm(current_skyline_app, parent_pid, timeseries, algorithm_paramet
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int

--- a/skyline/custom_algorithms/pca.py
+++ b/skyline/custom_algorithms/pca.py
@@ -76,7 +76,7 @@ def pca(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
+        Example usage::
         
             algorithm_parameters={
                 'anomaly_window': 1,
@@ -88,6 +88,7 @@ def pca(current_skyline_app, parent_pid, timeseries, algorithm_parameters):
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int

--- a/skyline/custom_algorithms/probabilistic_forecasts_generalized_pareto_distribution_ets.py
+++ b/skyline/custom_algorithms/probabilistic_forecasts_generalized_pareto_distribution_ets.py
@@ -110,8 +110,8 @@ def probabilistic_forecasts_generalized_pareto_distribution_ets(current_skyline_
             If ``True``, returns the addition data in the results dict.  Default
             is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'threshold': 0.95,
@@ -119,6 +119,7 @@ def probabilistic_forecasts_generalized_pareto_distribution_ets(current_skyline_
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -140,7 +141,13 @@ def probabilistic_forecasts_generalized_pareto_distribution_ets(current_skyline_
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {}
+    anomalies = {}
+    scores = []
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores, 'results': {}
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/skyline_laoccfdlpnc.py
+++ b/skyline/custom_algorithms/skyline_laoccfdlpnc.py
@@ -136,7 +136,11 @@ def skyline_laoccfdlpnc(current_skyline_app, parent_pid, timeseries, algorithm_p
     anomalyScore = None
     anomalies = {}
     scores = []
-    results = {'anomalous': False, 'anomalies': anomalies, 'scores': scores, 'results': {}}
+    anomalyScore_list = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores, 'results': {}
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/skyline_matrixprofile.py
+++ b/skyline/custom_algorithms/skyline_matrixprofile.py
@@ -146,7 +146,7 @@ def skyline_matrixprofile(current_skyline_app, parent_pid, timeseries, algorithm
             the :mod:`settings.FLUX_SELF_API_KEY` or a key from
             :mod:`settings.FLUX_API_KEYS`.  Required only if tornado is being
             used.  Default is ``None``.
-        Example usage:
+        Example usage::
 
             algorithm_parameters={
                 'anomaly_window': 3,
@@ -158,6 +158,8 @@ def skyline_matrixprofile(current_skyline_app, parent_pid, timeseries, algorithm
                 'debug_logging': True,
                 'return_results': True,
             }
+
+
     :type current_skyline_app: str
     :type parent_pid: int
     :type timeseries: list
@@ -181,8 +183,14 @@ def skyline_matrixprofile(current_skyline_app, parent_pid, timeseries, algorithm
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {'anomalous': False, 'anomalies': [], 'matrixprofile_scores': []}
-
+    anomalyScore_list = []
+    scores = []
+    anomalies = {}
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores,
+        'matrixprofile_scores': [], 'results': {}
+    }
     current_logger = None
 
     # If you wanted to log, you can but this should only be done during
@@ -359,6 +367,14 @@ def skyline_matrixprofile(current_skyline_app, parent_pid, timeseries, algorithm
         except:
             # Default to discovering 20 discords
             k_discords = 20
+
+    # @added 20250110 - Feature #4734: mirage_vortex
+    # Allow mirage_vortex to pass downsample parameter
+    downsample = True
+    try:
+        downsample = algorithm_parameters['downsample']
+    except:
+        downsample = True
 
     # @added 20240129 - Feature #5198: flux - tornado
     # Do not use flux tornado for skyline_matrixprofile if required
@@ -539,6 +555,15 @@ def skyline_matrixprofile(current_skyline_app, parent_pid, timeseries, algorithm
                     current_logger.error('error :: debug_logging :: %s :: resolution failed - %s' % (
                         func_name, err))
 
+        # @added 20250110 - Feature #4734: mirage_vortex
+        # Allow mirage_vortex to pass downsample parameter
+        if not downsample:
+            if downsample_data:
+                downsample_data = False
+                if debug_logging:
+                    current_logger.debug('debug :: %s :: downsample parameter passed as False not downsampling' % (
+                        func_name))
+
         downsampled_timeseries = []
         if downsample_data:
             original_timeseries = list(timeseries)
@@ -612,6 +637,16 @@ def skyline_matrixprofile(current_skyline_app, parent_pid, timeseries, algorithm
 
             # Do not reverse - after the right yssiM
             # dataset = dataset[::-1]
+            # @added 20250203 - tonight it finally dawned on me why reversing
+            # the time series worked, but was not the correct way so it was
+            # reverted but it worked.  The trigger_override was not a great
+            # method but improved no trigger_override and the TSAID made it
+            # clear as to why all that was required.  And now as to why reversed
+            # worked in the anomaly detection context.  Because the final
+            # window was evaluated as the first and when reversed to determine
+            # the result would often flag the final data point as anomalous,
+            # which is run unreversed would not, which just occurred to me this
+            # evening :)
 
             ts = np.array(dataset)
         except Exception as err:

--- a/skyline/custom_algorithms/skyline_prophet.py
+++ b/skyline/custom_algorithms/skyline_prophet.py
@@ -87,8 +87,8 @@ def skyline_prophet(current_skyline_app, parent_pid, timeseries, algorithm_param
                 If ``True``, enables debug printing  (for Jupyter testing).
                 Default is ``False``.
 
-        Example usage:
-        
+        Example usage::
+
             algorithm_parameters={
                 'anomaly_window': 1,
                 'interval_width': 0.99,
@@ -100,6 +100,7 @@ def skyline_prophet(current_skyline_app, parent_pid, timeseries, algorithm_param
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int
@@ -150,7 +151,13 @@ def skyline_prophet(current_skyline_app, parent_pid, timeseries, algorithm_param
     # anomalyScore.
     anomalous = None
     anomalyScore = None
-    results = {'anomalies': [], 'prophet_scores': []}
+    anomalyScore_list = []
+    scores = []
+    results = {
+        'anomalous': False, 'anomalies': anomalies,
+        'anomalyScore_list': anomalyScore_list, 'scores': scores,
+        'prophet_scores': [], 'results': {}
+    }
 
     current_logger = None
 

--- a/skyline/custom_algorithms/spectral_entropy.py
+++ b/skyline/custom_algorithms/spectral_entropy.py
@@ -79,7 +79,7 @@ def spectral_entropy(current_skyline_app, parent_pid, timeseries, algorithm_para
             If ``True``, enables debug printing  (for Jupyter testing). Default
             is ``False``.
 
-        Example usage:
+        Example usage::
         
             algorithm_parameters={
                 'anomaly_window': 1,
@@ -89,6 +89,7 @@ def spectral_entropy(current_skyline_app, parent_pid, timeseries, algorithm_para
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type current_skyline_app: str
     :type parent_pid: int

--- a/skyline/custom_algorithms/spectral_residual.py
+++ b/skyline/custom_algorithms/spectral_residual.py
@@ -127,7 +127,7 @@ def spectral_residual(current_skyline_app, parent_pid, timeseries, algorithm_par
                 If ``True``, enables debug printing  (for Jupyter testing).
                 Default is ``False``.
 
-        Example usage:
+        Example usage::
         
             algorithm_parameters={
                 'anomaly_window': 3,
@@ -136,6 +136,7 @@ def spectral_residual(current_skyline_app, parent_pid, timeseries, algorithm_par
                 'debug_logging': True,
                 'return_results': True,
             }
+
 
     :type algorithm_parameters: dict
     :type current_skyline_app: str
@@ -301,10 +302,10 @@ def spectral_residual(current_skyline_app, parent_pid, timeseries, algorithm_par
             current_logger.debug('debug :: running SpectralResidual on X with %s datapoints' % str(len(X)))
         start = timer()
         od = SpectralResidual(
-            threshold=threshold,             # threshold for outlier score
-            window_amp=20,                   # window for the average log amplitude
-            window_local=20,                 # window for the average saliency map
-            n_est_points=20,                 # nb of estimated points padded to the end of the sequence
+            threshold=threshold,                        # threshold for outlier score
+            window_amp=window_amp,                      # window for the average log amplitude
+            window_local=window_local,                  # window for the average saliency map
+            n_est_points=n_est_points,                  # nb of estimated points padded to the end of the sequence
             padding_amp_method=padding_amp_method,      # padding method to be used prior to each convolution over log amplitude.
             padding_local_method=padding_local_method,  # padding method to be used prior to each convolution over saliency map.
             padding_amp_side=padding_amp_side           # whether to pad the amplitudes on both sides or only on one side.


### PR DESCRIPTION
IssueID #5710: utcfromtimestamp - deprecated datetime and pandas
IssueID #5519: functions.skyline.coerce_to_valid_json
IssueID #5518: custom_algorithms_results - invalid JSON
IssueID #5635: statsmodels - adfuller handle constant
IssueID #5593: statsmodels adfuller error in Analyzer

- Minimal docstrings syntax changes
- Defined default initial variables for v5.0.0 custom_algorithms
- Deprecate the use of utcfromtimestamp where required
- Coerce results to valid json where required

Modified:
skyline/custom_algorithm_sources/sigma/sigma.py
skyline/custom_algorithms/adtk_level_shift.py
skyline/custom_algorithms/adtk_persist.py
skyline/custom_algorithms/adtk_seasonal.py
skyline/custom_algorithms/adtk_volatility_shift.py skyline/custom_algorithms/anomalous_daily_peak.py
skyline/custom_algorithms/azure_ai_anomalydetector.py skyline/custom_algorithms/dbscan.py
skyline/custom_algorithms/grafana_promql_anomaly_detection.py skyline/custom_algorithms/irregular_unstable.py
skyline/custom_algorithms/isolation_forest.py
skyline/custom_algorithms/lad.py
skyline/custom_algorithms/laoccfdlpnc.py
skyline/custom_algorithms/lof.py
skyline/custom_algorithms/low_variance_anomalous_peak_trough.py skyline/custom_algorithms/m66.py
skyline/custom_algorithms/macd.py
skyline/custom_algorithms/mmzrmp.py
skyline/custom_algorithms/mstl.py
skyline/custom_algorithms/one_class_svm.py
skyline/custom_algorithms/pca.py
skyline/custom_algorithms/probabilistic_forecasts_generalized_pareto_distribution_ets.py skyline/custom_algorithms/skyline_laoccfdlpnc.py
skyline/custom_algorithms/skyline_matrixprofile.py skyline/custom_algorithms/skyline_prophet.py
skyline/custom_algorithms/spectral_entropy.py
skyline/custom_algorithms/spectral_residual.py