### PR TITLE
Update service files for v5.0.0

### DIFF
--- a/etc/systemd/system/analyzer.service
+++ b/etc/systemd/system/analyzer.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/analyzer.d start
 ExecStop=/opt/skyline/github/skyline/bin/analyzer.d stop
-PIDFile=/var/run/skyline/analyzer.pid
+PIDFile=/run/skyline/analyzer.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/analyzer_batch.service
+++ b/etc/systemd/system/analyzer_batch.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/analyzer_batch.d start
 ExecStop=/opt/skyline/github/skyline/bin/analyzer_batch.d stop
-PIDFile=/var/run/skyline/analyzer_batch.pid
+PIDFile=/run/skyline/analyzer_batch.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/boundary.service
+++ b/etc/systemd/system/boundary.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/boundary.d start
 ExecStop=/opt/skyline/github/skyline/bin/boundary.d stop
-PIDFile=/var/run/skyline/boundary.pid
+PIDFile=/run/skyline/boundary.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/crucible.service
+++ b/etc/systemd/system/crucible.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/crucible.d start
 ExecStop=/opt/skyline/github/skyline/bin/crucible.d stop
-PIDFile=/var/run/skyline/crucible.pid
+PIDFile=/run/skyline/crucible.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/flux.service
+++ b/etc/systemd/system/flux.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/flux.d start
 ExecStop=/opt/skyline/github/skyline/bin/flux.d stop
-PIDFile=/var/run/skyline/flux.pid
+PIDFile=/run/skyline/flux.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/horizon.service
+++ b/etc/systemd/system/horizon.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/horizon.d start
 ExecStop=/opt/skyline/github/skyline/bin/horizon.d stop
-PIDFile=/var/run/skyline/horizon.pid
+PIDFile=/run/skyline/horizon.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/ionosphere.service
+++ b/etc/systemd/system/ionosphere.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/ionosphere.d start
 ExecStop=/opt/skyline/github/skyline/bin/ionosphere.d stop
-PIDFile=/var/run/skyline/ionosphere.pid
+PIDFile=/run/skyline/ionosphere.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/luminosity.service
+++ b/etc/systemd/system/luminosity.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/luminosity.d start
 ExecStop=/opt/skyline/github/skyline/bin/luminosity.d stop
-PIDFile=/var/run/skyline/luminosity.pid
+PIDFile=/run/skyline/luminosity.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/mirage.service
+++ b/etc/systemd/system/mirage.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/mirage.d start
 ExecStop=/opt/skyline/github/skyline/bin/mirage.d stop
-PIDFile=/var/run/skyline/mirage.pid
+PIDFile=/run/skyline/mirage.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/panorama.service
+++ b/etc/systemd/system/panorama.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/panorama.d start
 ExecStop=/opt/skyline/github/skyline/bin/panorama.d stop
-PIDFile=/var/run/skyline/panorama.pid
+PIDFile=/run/skyline/panorama.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/snab.service
+++ b/etc/systemd/system/snab.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/snab.d start
 ExecStop=/opt/skyline/github/skyline/bin/snab.d stop
-PIDFile=/var/run/skyline/snab.pid
+PIDFile=/run/skyline/snab.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/snab_flux_load_test.service
+++ b/etc/systemd/system/snab_flux_load_test.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/snab_flux_load_test.d start
 ExecStop=/opt/skyline/github/skyline/bin/snab_flux_load_test.d stop
-PIDFile=/var/run/skyline/snab_flux_load_test.pid
+PIDFile=/run/skyline/snab_flux_load_test.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/thunder.service
+++ b/etc/systemd/system/thunder.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/thunder.d start
 ExecStop=/opt/skyline/github/skyline/bin/thunder.d stop
-PIDFile=/var/run/skyline/thunder.pid
+PIDFile=/run/skyline/thunder.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/vista.service
+++ b/etc/systemd/system/vista.service
@@ -15,7 +15,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/vista.d start
 ExecStop=/opt/skyline/github/skyline/bin/vista.d stop
-PIDFile=/var/run/skyline/vista.pid
+PIDFile=/run/skyline/vista.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 

--- a/etc/systemd/system/webapp.service
+++ b/etc/systemd/system/webapp.service
@@ -16,7 +16,7 @@ RuntimeDirectoryMode=0755
 RuntimeDirectoryPreserve=yes
 ExecStart=/opt/skyline/github/skyline/bin/webapp.d start
 ExecStop=/opt/skyline/github/skyline/bin/webapp.d stop
-PIDFile=/var/run/skyline/webapp.pid
+PIDFile=/run/skyline/webapp.pid
 #TimeoutStartSec=180
 TimeoutStopSec=5
 


### PR DESCRIPTION
- Deprecate /var/run/skyline from service files and use /run/skyline

Modified:
etc/systemd/system/analyzer.service
etc/systemd/system/analyzer_batch.service
etc/systemd/system/boundary.service
etc/systemd/system/crucible.service
etc/systemd/system/flux.service
etc/systemd/system/horizon.service
etc/systemd/system/ionosphere.service
etc/systemd/system/luminosity.service
etc/systemd/system/mirage.service
etc/systemd/system/panorama.service
etc/systemd/system/snab.service
etc/systemd/system/snab_flux_load_test.service
etc/systemd/system/thunder.service
etc/systemd/system/vista.service
etc/systemd/system/webapp.service