### PR TITLE
fix: correct falied to failed typo in bin/*.d scripts (16 instances)

### DIFF
--- a/bin/analyzer.d
+++ b/bin/analyzer.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/analyzer_batch.d
+++ b/bin/analyzer_batch.d
@@ -360,7 +360,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/analyzer_dev.d
+++ b/bin/analyzer_dev.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/boundary.d
+++ b/bin/boundary.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/crucible.d
+++ b/bin/crucible.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/flux.d
+++ b/bin/flux.d
@@ -325,7 +325,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/horizon.d
+++ b/bin/horizon.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/ionosphere.d
+++ b/bin/ionosphere.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/luminosity.d
+++ b/bin/luminosity.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/mirage.d
+++ b/bin/mirage.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/panorama.d
+++ b/bin/panorama.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/snab.d
+++ b/bin/snab.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/snab_flux_load_test.d
+++ b/bin/snab_flux_load_test.d
@@ -349,7 +349,7 @@ stop () {
     if [[ -f "$PID_PATH/${SUB_SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SUB_SERVICE_NAME}.d :: error - failed to stop all ${SUB_SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SUB_SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SUB_SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SUB_SERVICE_NAME}.log"
-      echo "$SUB_SERVICE_NAME.d falied to stop all $SUB_SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SUB_SERVICE_NAME.d failed to stop all $SUB_SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/thunder.d
+++ b/bin/thunder.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/vista.d
+++ b/bin/vista.d
@@ -348,7 +348,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 

--- a/bin/webapp.d
+++ b/bin/webapp.d
@@ -422,7 +422,7 @@ stop () {
     if [[ -f "$PID_PATH/${SERVICE_NAME}.pid" && $PROCESS_COUNT -gt 0 ]]; then
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - failed to stop all ${SERVICE_NAME} processes and pid file remains" >> "$LOG_PATH/${SERVICE_NAME}.log"
       echo "$(date +"%Y-%m-%d %H:%M:%S") :: $PID :: ${SERVICE_NAME}.d :: error - there maybe zombies or multiple instances running" >> "$LOG_PATH/${SERVICE_NAME}.log"
-      echo "$SERVICE_NAME.d falied to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
+      echo "$SERVICE_NAME.d failed to stop all $SERVICE_NAME processes, there maybe zombies or multiple instances running"
       RETVAL=1
     fi
 


### PR DESCRIPTION
Correct `falied` to `failed` typo in 16 shell scripts in `bin/` directory. User-facing echo messages when daemon stop operations fail.