### PR TITLE
ionosphere.learn_self_validation, et al

### DIFF
--- a/skyline/functions/database/queries/get_all_fps.py
+++ b/skyline/functions/database/queries/get_all_fps.py
@@ -9,6 +9,10 @@ from database import get_engine, engine_disposal, ionosphere_table_meta
 # @added 20241127 - Bug #5522: Handle duplicate metric names
 from skyline_functions import get_redis_conn_decoded
 
+# @added 20260708 - Feature #5764: get_ionosphere_disabled_fp_ids
+#                   Feature #5572: get_all_fps
+#                   Feature #3890: metrics_manager - sync_cluster_files
+from functions.database.queries.get_ionosphere_disabled_fp_ids import get_ionosphere_disabled_fp_ids
 
 # @added 20241213 - Feature #5572: get_all_fps
 #                   Bug #5571: v5.0.0-alplha - regression on cluster nodes - mysql.aborted_clients
@@ -35,6 +39,11 @@ def get_all_fps(current_skyline_app, enabled_only=False):
     current_skyline_app_logger = current_skyline_app + 'Log'
     current_logger = logging.getLogger(current_skyline_app_logger)
 
+    # @added 20260708 - Feature #5764: get_ionosphere_disabled_fp_ids
+    #                   Feature #5572: get_all_fps
+    # Ensure disabled fp ids are current in the ionosphere.fp_ids_with_enabled
+    # Redis hash
+    disabled_fp_ids = []
     try:
         redis_conn_decoded = get_redis_conn_decoded(current_skyline_app)
     except Exception as err:
@@ -42,6 +51,37 @@ def get_all_fps(current_skyline_app, enabled_only=False):
         current_logger.error(trace)
         fail_msg = 'error :: %s :: get_redis_conn_decoded failed, err: %s' % (function_str, err)
         current_logger.error('%s' % fail_msg)
+    try:
+        disabled_fp_ids = list(redis_conn_decoded.smembers('latest.ionosphere.disabled.fp_ids'))
+    except Exception as err:
+        trace = traceback.format_exc()
+        current_logger.error(trace)
+        fail_msg = 'error :: %s :: smembers on latest.ionosphere.disabled.fp_ids failed, err: %s' % (function_str, err)
+        current_logger.error('%s' % fail_msg)
+    if disabled_fp_ids:
+        current_logger.info('%s :: got %s disabled fp ids from latest.ionosphere.disabled.fp_ids Redis set' % (
+            function_str, str(len(disabled_fp_ids))))
+
+    # Only fetch from the DB directly and set in the hash if the
+    # get_ionosphere_disabled_fp_ids Redis set latest.ionosphere.disabled.fp_ids
+    # has expired
+    if not disabled_fp_ids:
+        try:
+            disabled_fp_ids = get_ionosphere_disabled_fp_ids(current_skyline_app)
+        except Exception as err:
+            trace = traceback.format_exc()
+            current_logger.error(trace)
+            fail_msg = 'error :: %s :: get_ionosphere_disabled_fp_ids failed, err: %s' % (function_str, err)
+            current_logger.error('%s' % fail_msg)
+        if disabled_fp_ids:
+            disabled_fp_ids_dict = {fp_id: 0 for fp_id in disabled_fp_ids}
+            try:
+                redis_conn_decoded.hset('ionosphere.fp_ids_with_enabled', mapping=disabled_fp_ids_dict)
+                current_logger.info('%s :: added %s disabled fp ids to ionosphere.fp_ids_with_enabled' % (
+                    function_str, str(len(disabled_fp_ids_dict))))
+            except Exception as err:
+                current_logger.error('error :: %s :: failed to add %s fps ionosphere.fp_ids_with_enabled, err: %s' % (
+                    function_str, str(len(disabled_fp_ids_dict)), err))
 
     # To ensure that operations are fast instead of using a hash with dict
     # strings and literal_eval on each (slow), there is a hash for each
@@ -185,7 +225,7 @@ def get_all_fps(current_skyline_app, enabled_only=False):
             #connection.close()
         except Exception as err:
             current_logger.error(traceback.format_exc())
-            current_logger.error('error :: %s :: failed to select fps > id: %s from the ionosphere table, err: %s' % (
+            current_logger.error('error :: %s :: failed to determine fps > id: %s from the ionosphere table, err: %s' % (
                 function_str, str(last_redis_fp_id), err))
     if fps_with_errors:
         current_logger.error('error :: %s :: fps_with_errors[-1]: %s' % (
@@ -228,7 +268,7 @@ def get_all_fps(current_skyline_app, enabled_only=False):
             #connection.close()
         except Exception as err:
             current_logger.error(traceback.format_exc())
-            current_logger.error('error :: %s :: failed to select fps_to_update from the ionosphere table, err: %s' % (
+            current_logger.error('error :: %s :: failed to determine fps_to_update from the ionosphere table, err: %s' % (
                 function_str, err))
         current_logger.info('%s :: added %s fps_to_update to fps_to_add_to_redis' % (
             function_str, str(len(fps_to_update))))

--- a/skyline/functions/database/queries/get_ionosphere_disabled_fp_ids.py
+++ b/skyline/functions/database/queries/get_ionosphere_disabled_fp_ids.py
@@ -1,0 +1,112 @@
+import logging
+import traceback
+
+from sqlalchemy.sql import select
+
+from database import get_engine, engine_disposal, ionosphere_table_meta
+from skyline_functions import get_redis_conn_decoded
+
+
+# @added 20260708 - Feature #5764: get_ionosphere_disabled_fp_ids
+#                   Feature #5572: get_all_fps
+#                   Feature #3890: metrics_manager - sync_cluster_files
+def get_ionosphere_disabled_fp_ids(current_skyline_app):
+    """
+    Return the list of fp_ids that are disabled in the database.
+    """
+    function_str = 'functions.database.queries.get_ionosphere_disabled_fp_ids'
+    log_msg = None
+    trace = None
+
+    current_skyline_app_logger = current_skyline_app + 'Log'
+    current_logger = logging.getLogger(current_skyline_app_logger)
+    disabled_fp_ids = []
+
+    current_logger.info('%s :: determining disabled fp_ids from the DB' % (
+        function_str))
+
+    try:
+        engine, fail_msg, trace = get_engine(current_skyline_app)
+    except Exception as err:
+        trace = traceback.format_exc()
+        current_logger.error(trace)
+        fail_msg = 'error :: %s :: could not get a MySQL engine, err: %s' % (function_str, err)
+        current_logger.error('%s' % fail_msg)
+        if engine:
+            engine_disposal(current_skyline_app, engine)
+        if current_skyline_app == 'webapp':
+            # Raise to webapp
+            raise
+        return disabled_fp_ids
+
+    try:
+        ionosphere_table, log_msg, trace = ionosphere_table_meta(current_skyline_app, engine)
+    except Exception as err:
+        current_logger.error(traceback.format_exc())
+        current_logger.error('error :: %s :: failed to get ionosphere_table meta, err: %s' % (
+            function_str, err))
+        if engine:
+            engine_disposal(current_skyline_app, engine)
+        if current_skyline_app == 'webapp':
+            # Raise to webapp
+            raise
+        return disabled_fp_ids
+
+    results = []
+    try:
+        stmt = select(ionosphere_table.c.id).\
+            where(ionosphere_table.c.enabled == 0)
+        with engine.connect() as connection:
+            result = connection.execute(stmt)
+            results = [dict(row._mapping) for row in result.fetchall()]
+    except Exception as err:
+        current_logger.error(traceback.format_exc())
+        current_logger.error('error :: %s :: could not get disabled fp_ids, err: %s' % (
+            function_str, err))
+        if engine:
+            engine_disposal(current_skyline_app, engine)
+        if current_skyline_app == 'webapp':
+            # Raise to webapp
+            raise
+        return disabled_fp_ids
+
+    errors = []
+    for row in results:
+        try:
+            disabled_fp_ids.append(row['id'])
+        except Exception as err:
+            errors.append([err])
+    if errors:
+        current_logger.error('error :: %s :: errors reported in determining disabled fp_ids, errors[0]: %s' % (
+            function_str, str(errors[0])))
+
+    current_logger.info('%s :: determined %s disabled fp_ids from the DB' % (
+        function_str, str(len(disabled_fp_ids))))
+
+    # Create the latest.ionosphere.disabled.fp_ids Redis set which expires every
+    # 30 minutes.
+    if disabled_fp_ids:
+        try:
+            redis_conn_decoded = get_redis_conn_decoded(current_skyline_app)
+        except Exception as err:
+            trace = traceback.format_exc()
+            current_logger.error(trace)
+            fail_msg = 'error :: %s :: get_redis_conn_decoded failed, err: %s' % (function_str, err)
+            current_logger.error('%s' % fail_msg)
+        try:
+            redis_conn_decoded.sadd('latest.ionosphere.disabled.fp_ids', *(disabled_fp_ids))
+            redis_conn_decoded.expire('latest.ionosphere.disabled.fp_ids', 1800)
+        except Exception as err:
+            trace = traceback.format_exc()
+            current_logger.error(trace)
+            fail_msg = 'error :: %s :: get_redis_conn_decoded failed, err: %s' % (function_str, err)
+            current_logger.error('%s' % fail_msg)
+
+
+    if engine:
+        engine_disposal(current_skyline_app, engine)
+    if log_msg:
+        del log_msg
+    if trace:
+        del trace
+    return disabled_fp_ids

--- a/skyline/ionosphere/learn_self_validation.py
+++ b/skyline/ionosphere/learn_self_validation.py
@@ -704,7 +704,11 @@ def self_validation(last_self_validate_timestamp):
             if validate_fp:
                 logger.info('%s :: validating fp_id: %s, validation_method: %s' % (
                     function_str, str(fp_id), str(validation_method)))
-                validation_link = fp_data['validation_link']
+                # @modified 202600705 - Feature #5644: ionosphere.learn_self_validation
+                #                       Feature #5318: common_motifs
+                # Added self_validated
+                validation_link = fp_data['validation_link'] + '&self_validated=true'
+
                 rv = None
                 try:            
                     if user and password:
@@ -751,6 +755,11 @@ def self_validation(last_self_validate_timestamp):
                     except Exception as err:
                         logger.error('error :: %s :: insert_comment failed, err: %s' % (
                             function_str, err))
+                    # @added 20260705 - Feature #5644: ionosphere.learn_self_validation
+                    #                   Feature #5318: common_motifs
+                    # Added self_validated_only
+
+
         except Exception as err:
             logger.error(traceback.format_exc())
             logger.error('error :: learn_self_validation :: failed to process fp_id: %s, err: %s' % (

--- a/skyline/tsfresh_features/autobuild_features_profile_tables.py
+++ b/skyline/tsfresh_features/autobuild_features_profile_tables.py
@@ -32,7 +32,9 @@ import sqlalchemy
 from sqlalchemy import (
     create_engine, Column, Table, Integer, MetaData)
 from sqlalchemy.dialects.mysql import DOUBLE
-from sqlalchemy.sql import select
+# @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
+# Added insert
+from sqlalchemy.sql import select, insert
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 parent_dir = os.path.join(os.path.dirname(os.path.realpath(current_dir)))
@@ -57,12 +59,24 @@ if __name__ == '__main__':
     tables_created = 0
 
     def get_engine():
+
+        # @added 20260628 - Feature #5757: DB TLS/SSL support
+        PANORAMA_DB_SSL = {}
+        if getattr(settings, 'PANORAMA_DB_SSL', {}):
+            PANORAMA_DB_SSL = getattr(settings, 'PANORAMA_DB_SSL', {})
+            if len(PANORAMA_DB_SSL) > 0:
+                if 'use_pure' not in PANORAMA_DB_SSL.keys():
+                    PANORAMA_DB_SSL['use_pure'] = True
+
         try:
             engine = create_engine(
                 'mysql+mysqlconnector://%s:%s@%s:%s/%s' % (
                     settings.PANORAMA_DBUSER, settings.PANORAMA_DBUSERPASS,
                     settings.PANORAMA_DBHOST, str(settings.PANORAMA_DBPORT),
-                    settings.PANORAMA_DATABASE))
+                    settings.PANORAMA_DATABASE),
+                    # @added 20260621 - Feature #5757: DB TLS/SSL support
+                    connect_args=PANORAMA_DB_SSL,
+            )
             return engine, 'got MySQL engine', 'none'
         except:
             print('error :: DB engine not obtained')
@@ -85,10 +99,21 @@ if __name__ == '__main__':
     # get all fp ids and metric ids from ionosphere table
     fps_data = []
     try:
-        connection = engine.connect()
-        stmt = select([ionosphere_table]).where(ionosphere_table.c.metric_id > 0)
-        result = connection.execute(stmt)
-        for row in result:
+        #connection = engine.connect()
+        # @modified 20260225 - Task #5176: Migrate to sqlalchemy v2 API
+        #                      Task #5628: Build v5.0.0 and test
+        #stmt = select([ionosphere_table]).where(ionosphere_table.c.metric_id > 0)
+        stmt = select(ionosphere_table).where(ionosphere_table.c.metric_id > 0)
+
+        # @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
+        #                      Task #5628: Build v5.0.0 and test
+        #result = connection.execute(stmt)
+        #for row in result:
+        with engine.connect() as connection:
+            result = connection.execute(stmt)
+            results = [dict(row._mapping) for row in result.fetchall()]
+        for row in results:
+
             if row['enabled'] != 1:
                 continue
             if row['deleted'] == 1:
@@ -97,7 +122,7 @@ if __name__ == '__main__':
             metric_id = row['metric_id']
             anomaly_timestamp = row['anomaly_timestamp']
             fps_data.append([int(fp_id), int(metric_id), int(anomaly_timestamp)])
-        connection.close()
+        #connection.close()
     except:
         print('Failed to get ionosphere data from the database')
 
@@ -109,14 +134,24 @@ if __name__ == '__main__':
     # get all fp ids and metric ids from ionosphere table
     ionosphere_metrics_data = []
     try:
-        connection = engine.connect()
-        stmt = select([metrics_table]).where(metrics_table.c.ionosphere_enabled > 0)
-        result = connection.execute(stmt)
-        for row in result:
+        #connection = engine.connect()
+        # @modified 20260225 - Task #5176: Migrate to sqlalchemy v2 API
+        #                      Task #5628: Build v5.0.0 and test
+        #stmt = select([metrics_table]).where(metrics_table.c.ionosphere_enabled > 0)
+        stmt = select(metrics_table).where(metrics_table.c.ionosphere_enabled > 0)
+        # @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
+        #                      Task #5628: Build v5.0.0 and test
+        #result = connection.execute(stmt)
+        #for row in result:
+        with engine.connect() as connection:
+            result = connection.execute(stmt)
+            results = [dict(row._mapping) for row in result.fetchall()]
+        for row in results:
+
             metric_id = row['id']
             metric = row['metric']
             ionosphere_metrics_data.append([int(metric_id), str(metric)])
-        connection.close()
+        #connection.close()
     except:
         print('Failed to get metrics data from the database')
 
@@ -223,9 +258,14 @@ if __name__ == '__main__':
                 continue
 
             try:
-                connection = engine.connect()
-                connection.execute(fp_metric_table.insert(), insert_statement)
-                connection.close()
+                # @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
+                #                      Task #5628: Build v5.0.0 and test
+                #connection = engine.connect()
+                #connection.execute(fp_metric_table.insert(), insert_statement)
+                #connection.close()
+                with engine.begin() as connection:
+                    connection.execute(insert(fp_metric_table), insert_statement)
+
                 print('create_features_profile :: fp_id - %s - feature values inserted into %s' % (str(fp_id), fp_table_name))
             except:
                 print(traceback.format_exc())
@@ -284,7 +324,7 @@ if __name__ == '__main__':
                     new_datapoint = [str(int(datapoint[0])), float(datapoint[1])]
                     validated_timeseries.append(new_datapoint)
                 # @modified 20170913 - Task #2160: Test skyline with bandit
-                # Added nosec to exclude from bandit tests
+                # Added "nosec" to exclude from bandit tests
                 except:  # nosec
                     continue
 
@@ -292,9 +332,14 @@ if __name__ == '__main__':
             for ts, value in validated_timeseries:
                 insert_statement.append({'fp_id': fp_id, 'timestamp': ts, 'value': value},)
             try:
-                connection = engine.connect()
-                connection.execute(ts_metric_table.insert(), insert_statement)
-                connection.close()
+                # @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
+                #                      Task #5628: Build v5.0.0 and test
+                #connection = engine.connect()
+                #connection.execute(ts_metric_table.insert(), insert_statement)
+                #connection.close()
+                with engine.begin() as connection:
+                    connection.execute(insert(ts_metric_table), insert_statement)
+
                 print('create_features_profile :: fp_id - %s - timeseries inserted into %s' % (str(fp_id), ts_table_name))
             except:
                 print(traceback.format_exc())

--- a/skyline/webapp/backend.py
+++ b/skyline/webapp/backend.py
@@ -554,8 +554,10 @@ def panorama_request():
                 # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                 #                      Task #5628: Build v5.0.0 and test
                 #query = text("""SELECT id FROM algorithms WHERE algorithm LIKE :like_string""")
-                metrics_like_text = f"SELECT id FROM algorithms WHERE algorithm LIKE '{for_algorithm}'"
-                query = text(metrics_like_text)
+                # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                #metrics_like_text = f"SELECT id FROM algorithms WHERE algorithm LIKE '{for_algorithm}'"
+                #query = text(metrics_like_text)
+                query = text("""SELECT id FROM algorithms WHERE algorithm LIKE :like_string""")
 
                 if not engine:
                     try:
@@ -581,7 +583,9 @@ def panorama_request():
                         # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                         #                      Task #5628: Build v5.0.0 and test
                         #result = connection.execute(query, like_string=str(for_algorithm))
-                        result = connection.execute(query)
+                        # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                        #result = connection.execute(query)
+                        result = connection.execute(query, {'like_string': for_algorithm})
 
                         results = [dict(row._mapping) for row in result.fetchall()]
 

--- a/skyline/webapp/common_motifs_to_validate.py
+++ b/skyline/webapp/common_motifs_to_validate.py
@@ -18,13 +18,17 @@ logfile = '%s/%s.log' % (settings.LOG_PATH, skyline_app)
 
 
 def get_common_motifs_to_validate(
-        from_timestamp, until_timestamp, state='unvalidated', namespace=None):
+        from_timestamp, until_timestamp, state='unvalidated', namespace=None,
+        # @added 20260705 - Feature #5644: ionosphere.learn_self_validation
+        #                   Feature #5318: common_motifs
+        # Added self_validated_only
+        self_validated_only=False):
     function_str = 'get_common_motifs_to_validate'
 
     common_motifs_fps = {}
 
-    logger.info('%s :: determining all %s common_motifs feature profiles for namespace %s' % (
-        function_str, state, str(namespace)))
+    logger.info('%s :: determining all %s common_motifs feature profiles for namespace %s, self_validated_only: %s' % (
+        function_str, state, str(namespace), str(self_validated_only)))
 
     try:
         engine, fail_msg, trace = get_engine(skyline_app)
@@ -53,6 +57,7 @@ def get_common_motifs_to_validate(
     try:
         #connection = engine.connect()
         if state == 'validated':
+            logger.info('%s :: stmt for %s' % (function_str, str(state)))
             # @modified 20260225 - Task #5176: Migrate to sqlalchemy v2 API
             #                      Task #5628: Build v5.0.0 and test
             #stmt = select([ionosphere_table]).\
@@ -63,6 +68,7 @@ def get_common_motifs_to_validate(
                 where(ionosphere_table.c.label == 'LEARNT - common_motifs').\
                 where(ionosphere_table.c.enabled == 1)
         elif state == 'invalid':
+            logger.info('%s :: stmt for %s' % (function_str, str(state)))
             # @modified 20260225 - Task #5176: Migrate to sqlalchemy v2 API
             #                      Task #5628: Build v5.0.0 and test
             #stmt = select([ionosphere_table]).\
@@ -71,7 +77,19 @@ def get_common_motifs_to_validate(
                 where(ionosphere_table.c.anomaly_timestamp <= until_timestamp).\
                 where(ionosphere_table.c.label == 'LEARNT - common_motifs').\
                 where(ionosphere_table.c.enabled == 0)
+        # @added 20260712 - Feature #5644: ionosphere.learn_self_validation
+        #                   Feature #5318: common_motifs
+        # With the addition of self_validated_only specifically check unvalidated
+        # as well
+        elif state == 'unvalidated':
+            logger.info('%s :: stmt for %s' % (function_str, str(state)))
+            stmt = select(ionosphere_table).\
+                where(ionosphere_table.c.anomaly_timestamp >= from_timestamp).\
+                where(ionosphere_table.c.anomaly_timestamp <= until_timestamp).\
+                where(ionosphere_table.c.label == 'LEARNT - common_motifs').\
+                where(ionosphere_table.c.validated == 0)
         else:
+            logger.info('%s :: stmt for %s' % (function_str, str(state)))
             # @modified 20260225 - Task #5176: Migrate to sqlalchemy v2 API
             #                      Task #5628: Build v5.0.0 and test
             #stmt = select([ionosphere_table]).\
@@ -81,15 +99,26 @@ def get_common_motifs_to_validate(
                 where(ionosphere_table.c.validated == 0).\
                 where(ionosphere_table.c.label == 'LEARNT - common_motifs').\
                 where(ionosphere_table.c.enabled == 1)
+
         # @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
         #                      Task #5628: Build v5.0.0 and test
         #results = connection.execute(stmt)
         with engine.connect() as connection:
             result = connection.execute(stmt)
             results = [dict(row._mapping) for row in result.fetchall()]
+        logger.info('%s :: %s results determined' % (function_str, str(len(results))))
+
         for row in results:
             try:
                 fp_id = int(row['id'])
+
+                # @added 20260705 - Feature #5644: ionosphere.learn_self_validation
+                #                   Feature #5318: common_motifs
+                # Added self_validated_only
+                if self_validated_only:
+                    if row['self_validated'] != 1:
+                        continue
+
                 common_motifs_fps[fp_id] = dict(row)
                 # Coerce for json
                 for key, item in common_motifs_fps[fp_id].items():
@@ -102,6 +131,8 @@ def get_common_motifs_to_validate(
                 logger.error('error :: %s :: bad row data, row: %s, err: %s' % (
                     function_str, str(row), row_err))
         #connection.close()
+        logger.info('%s :: %s common_motifs_fps determined' % (function_str, str(len(common_motifs_fps))))
+
     except Exception as err:
         trace = traceback.format_exc()
         logger.error('%s' % trace)

--- a/skyline/webapp/crucible_backend.py
+++ b/skyline/webapp/crucible_backend.py
@@ -197,8 +197,10 @@ def submit_crucible_job(
 
                 # @added 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                 #                      Task #5628: Build v5.0.0 and test
-                metrics_like_text = f"SELECT metric FROM metrics WHERE metric LIKE '{namespace}'"
-                metrics_like_query = text(metrics_like_text)
+                # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                #metrics_like_text = f"SELECT metric FROM metrics WHERE metric LIKE '{namespace}'"
+                #metrics_like_query = text(metrics_like_text)
+                metrics_like_query = text("""SELECT metric FROM metrics WHERE metric LIKE :like_string""")
 
                 # @modified 20260227 - Task #5176: Migrate to sqlalchemy v2 API
                 #                      Task #5628: Build v5.0.0 and test
@@ -209,7 +211,9 @@ def submit_crucible_job(
                     # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                     #                      Task #5628: Build v5.0.0 and test
                     #result = connection.execute(metrics_like_query, like_string=str(namespace))
-                    result = connection.execute(metrics_like_query)
+                    # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                    #result = connection.execute(metrics_like_query)
+                    result = connection.execute(metrics_like_query, {"like_string": namespace})
 
                     results = [dict(row._mapping) for row in result.fetchall()]
                 for row in results:

--- a/skyline/webapp/ionosphere_backend.py
+++ b/skyline/webapp/ionosphere_backend.py
@@ -456,9 +456,12 @@ def ionosphere_data(
                 if re.search('mirage.redis.json', file):
                     data_file = False
                 # @added 20230707 - Feature #4988: Allow snab to return and save results
-                if re.search('^snab\..*\.results\.json', file):
+                # @modified 20260707 - Feature #4988: Allow snab to return and save results
+                #if re.search('^snab\..*\.results\.json', file):
+                if re.search('^snab\\..*\\.results\\.json', file):
                     data_file = False
-                if re.search('^snab\..*\.results\.timeseries\.json', file):
+                #if re.search('^snab\..*\.results\.timeseries\.json', file):
+                if re.search('^snab\\..*\\.results\\.timeseries\\.json', file):
                     data_file = False
                 # @added 20230728 - Feature #4988: Allow snab to return and save results
                 if file.endswith('.downsampled.json'):
@@ -542,9 +545,10 @@ def ionosphere_data(
                         if re.search('mirage.redis.json', file):
                             data_file = False
                         # @added 20230707 - Feature #4988: Allow snab to return and save results
-                        if re.search('^snab\..*\.results\.json', file):
+                        # @modified 20260707 - Feature #4988: Allow snab to return and save results
+                        if re.search('^snab\\..*\\.results\\.json', file):
                             data_file = False
-                        if re.search('^snab\..*\.results\.timeseries\.json', file):
+                        if re.search('^snab\\..*\\.results\\.timeseries\\.json', file):
                             data_file = False
                         if re.search('\\d{10}', root) and data_file:
                             metric_name = file.replace('.json', '')
@@ -986,7 +990,8 @@ def ionosphere_metric_data(
             ionosphere_json_file = str(metric_file)
 
         # @added 20230707 - Feature #4988: Allow snab to return and save results
-        if re.search('^snab\..*\.results\.json', i_file):
+        # @modified 20260707 - Feature #4988: Allow snab to return and save results
+        if re.search('^snab\\..*\\.results\\.json', i_file):
             snab_results_file = str(metric_file)
 
             # @added 20231013 - Feature #5100: snab - allow for multiple checks
@@ -2637,8 +2642,10 @@ def ionosphere_search(default_query, search_query):
             # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
             #                      Task #5628: Build v5.0.0 and test
             #metrics_like_query = text("""SELECT id FROM metrics WHERE metric LIKE :like_string""")
-            metrics_like_text = f"SELECT id FROM metrics WHERE metric LIKE '{metric_like_str}'"
-            metrics_like_query = text(metrics_like_text)
+            # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+            #metrics_like_text = f"SELECT id FROM metrics WHERE metric LIKE '{metric_like_str}'"
+            #metrics_like_query = text(metrics_like_text)
+            metrics_like_query = text("SELECT id FROM metrics WHERE metric LIKE :like_string")
 
             # @added 20200404 - Task #3464: Optimise ionosphere_backend ionosphere_search queries
             logger.info('metrics_like_query - "%s"' % metrics_like_query)
@@ -2659,7 +2666,9 @@ def ionosphere_search(default_query, search_query):
                     # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                     #                      Task #5628: Build v5.0.0 and test
                     #result = connection.execute(metrics_like_query, like_string=metric_like_str)
-                    result = connection.execute(metrics_like_query)
+                    # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                    #result = connection.execute(metrics_like_query)
+                    result = connection.execute(metrics_like_query, {"like_string": metric_like_str})
 
                     results = [dict(row._mapping) for row in result.fetchall()]
                 for row in results:
@@ -2963,6 +2972,16 @@ def ionosphere_search(default_query, search_query):
                 fp_generation = int(row['generation'])
                 # @added 20170402 - Feature #2000: Ionosphere - validated
                 fp_validated = int(row['validated'])
+
+                # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+                # Added the fp_layers_id to align with the features_profile
+                # object created via the get_metric_profiles query and populated
+                # the enabled_list
+                fp_layers_id = int(row['layers_id'])
+                features_profile_enabled = int(row['enabled'])
+                if features_profile_enabled == 1:
+                    enabled_list.append(fp_id)
+
                 # @added 20210415 - Feature #4014: Ionosphere - inference
                 #                   Branch #3590: inference
                 motif_matched_count = int(row['motif_matched_count'])
@@ -2981,7 +3000,9 @@ def ionosphere_search(default_query, search_query):
                 # @modifed 20210415 - Feature #4014: Ionosphere - inference
                 #                     Branch #3590: inference
                 # all_fps.append([fp_id, fp_metric_id, str(fp_metric), full_duration, anomaly_timestamp, tsfresh_version, calc_time, features_count, features_sum, deleted, fp_matched_count, human_date, created_timestamp, fp_checked_count, checked_human_date, fp_parent_id, fp_generation, fp_validated])
-                all_fps.append([fp_id, fp_metric_id, str(fp_metric), full_duration, anomaly_timestamp, tsfresh_version, calc_time, features_count, features_sum, deleted, fp_matched_count, human_date, created_timestamp, fp_checked_count, checked_human_date, fp_parent_id, fp_generation, fp_validated, motif_matched_count, motif_last_matched_human_date, motif_last_checked_human_date, motif_checked_count])
+                # @modified 20260710 - Feature #5644: ionosphere.learn_self_validation
+                # Added fp_layers_id after fp_validated
+                all_fps.append([fp_id, fp_metric_id, str(fp_metric), full_duration, anomaly_timestamp, tsfresh_version, calc_time, features_count, features_sum, deleted, fp_matched_count, human_date, created_timestamp, fp_checked_count, checked_human_date, fp_parent_id, fp_generation, fp_validated, fp_layers_id, motif_matched_count, motif_last_matched_human_date, motif_last_checked_human_date, motif_checked_count])
                 # logger.info('%s :: %s feature profiles found' % (function_str, str(len(all_fps))))
             except:
                 trace = traceback.format_exc()
@@ -2989,6 +3010,9 @@ def ionosphere_search(default_query, search_query):
                 logger.error('error :: bad row data')
         #connection.close()
         all_fps.sort(key=operator.itemgetter(int(0)))
+        logger.info('all_fps contains %s fps and of which %s are enabled' % (
+            str(len(all_fps)), str(len(enabled_list))))
+
     except:
         trace = traceback.format_exc()
         logger.error('%s' % trace)
@@ -3125,6 +3149,12 @@ def ionosphere_search(default_query, search_query):
     # @added 20170322 - Feature #1960: ionosphere_layers
     # Added layers information to the features_profiles items
     layers_present = False
+
+    # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+    if all_fps and apply_metric_id:
+        features_profiles = [item for item in all_fps if item[17] == 0]
+        engine_needed = False    
+        logger.info('using optimised all_fps with validated=0, %s unvalidated fps determined' % str(len(features_profiles)))
 
     if engine_needed and engine and search_query:
         try:
@@ -3475,6 +3505,10 @@ def ionosphere_search(default_query, search_query):
                 engine_disposal(engine)
             raise
 
+    # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+    if all_fps and apply_metric_id:
+        logger.info('still using optimised all_fps with validated=0, before add layer info - len(features_profiles): %s' % str(len(features_profiles)))
+
     # Add the layers information to the features_profiles list
     features_profiles_and_layers = []
     if features_profiles:
@@ -3508,6 +3542,11 @@ def ionosphere_search(default_query, search_query):
 
         # old_features_profile_list = features_profiles
         features_profiles = features_profiles_and_layers
+
+        # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+        if all_fps and apply_metric_id:
+            logger.info('after adding layers info - len(features_profiles): %s, len(features_profiles_and_layers): %s' % (
+                str(len(features_profiles)), str(len(features_profiles_and_layers))))
 
         full_duration_list = None
         # @modified 20170912 - Feature #2056: ionosphere - disabled_features_profiles
@@ -5097,7 +5136,11 @@ def edit_ionosphere_layers(layers_id):
 #                      Feature #2516: Add label to features profile
 # Added user
 # def validate_fp(update_id, id_column_name):
-def validate_fp(update_id, id_column_name, user_id):
+# @modified 202600705 - Feature #5644: ionosphere.learn_self_validation
+#                       Feature #5318: common_motifs
+# Added self_validated
+#def validate_fp(update_id, id_column_name, user_id):
+def validate_fp(update_id, id_column_name, user_id, self_validated=False):
     """
     Validate a single features profile or validate all enabled, unvalidated
     features profiles for a metric_id.
@@ -5106,9 +5149,11 @@ def validate_fp(update_id, id_column_name, user_id):
     :type update_id: int
     :param id_column_name: the column name to select where on, e.g. id or metric_id
     :param user_id: the user id of the user that is validating
+    :param self_validated: if this is a self validation
     :type update_id: int
     :type id_column_name: str
     :type user_id: int
+    :type self_validated: bool
     :return: tuple
     :rtype:  (boolean, str, str)
 
@@ -5220,13 +5265,22 @@ def validate_fp(update_id, id_column_name, user_id):
             #    values(validated=1, user_id=user_id))
             stmt = ionosphere_table.update().\
                 where(ionosphere_table.c.id == int(fp_id)).values(
-                    validated=1, user_id=user_id)
+                    validated=1, user_id=user_id,
+                    # @added 20260705 - Feature #5644: ionosphere.learn_self_validation
+                    #                   Feature #5318: common_motifs
+                    # Added self_validated_only
+                    self_validated=self_validated)
             with engine.begin() as connection:
                 connection.execute(stmt)
 
         if id_column_name == 'metric_id':
+
+            # @modified 20260705 - Feature #5644: ionosphere.learn_self_validation
+            #                      Feature #5318: common_motifs
+            # Added self_validated_only
+            #    values(validated=1, user_id=user_id).\
             stmt = ionosphere_table.update().\
-                values(validated=1, user_id=user_id).\
+                values(validated=1, user_id=user_id, self_validated=self_validated).\
                 where(ionosphere_table.c.metric_id == int(update_id)).\
                 where(ionosphere_table.c.validated == 0).\
                 where(ionosphere_table.c.enabled == 1)
@@ -5716,6 +5770,24 @@ def disable_features_profile_family_tree(fp_ids):
                 engine_disposal(engine)
             raise
 
+        # @added 20260708 - Feature #5572: get_all_fps
+        #                   Feature #5764: get_ionosphere_disabled_fp_ids
+        # When a fp is disabled update the ionosphere.fp_ids_with_enabled Redis
+        # hash
+        try:
+            try:
+                redis_conn_decoded = get_redis_conn_decoded(skyline_app)
+            except Exception as err:
+                logger.error('error :: %s :: get_redis_conn_decoded failed for updating ionosphere.fp_ids_with_enabled, err: %s' % (
+                    function_str, err))
+            redis_conn_decoded.hset('ionosphere.fp_ids_with_enabled', int(fp_id), 0)
+            logger.info('updated Redis has ionosphere.fp_ids_with_enabled for %s and set to 0' % (str(fp_id)))
+        except Exception as err:
+            trace = traceback.format_exc()
+            logger.error(trace)
+            logger.error('error :: could not update ionosphere.fp_ids_with_enabled for fp_id %s, err: %s' % (
+                str(fp_id), err))
+
         # @added 20200516 - Bug #3546: Change ionosphere_enabled if all features profiles are disabled
         # Disable any related layers as well
         if layer_ids:
@@ -6139,7 +6211,9 @@ def get_fp_matches(metric, metric_like, get_fp_id, get_layer_id, from_timestamp,
             result = results
 
             for row in results:
-                fp_id = str(row[0])
+                # @modified 20260607 - Task #5176: Migrate to sqlalchemy v2 API
+                #fp_id = str(row[0])
+                fp_id = str(row['id'])
                 if fp_ids == '':
                     fp_ids = '%s' % (fp_id)
                 else:
@@ -6211,8 +6285,10 @@ def get_fp_matches(metric, metric_like, get_fp_id, get_layer_id, from_timestamp,
             # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
             #                      Task #5628: Build v5.0.0 and test
             #metrics_like_query = text("""SELECT id FROM metrics WHERE metric LIKE :like_string""")
-            metrics_like_text = f"SELECT id FROM metrics WHERE metric LIKE '{python_escaped_metric_like}'"
-            metrics_like_query = text(metrics_like_text)
+            # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+            #metrics_like_text = f"SELECT id FROM metrics WHERE metric LIKE '{python_escaped_metric_like}'"
+            #metrics_like_query = text(metrics_like_text)
+            metrics_like_query = text("SELECT id FROM metrics WHERE metric LIKE :like_string")
 
             metric_ids_list = []
 
@@ -6232,7 +6308,9 @@ def get_fp_matches(metric, metric_like, get_fp_id, get_layer_id, from_timestamp,
                     # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                     #                      Task #5628: Build v5.0.0 and test
                     #result = connection.execute(metrics_like_query, like_string=str(python_escaped_metric_like))
-                    result = connection.execute(metrics_like_query)
+                    # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                    #result = connection.execute(metrics_like_query)
+                    result = connection.execute(metrics_like_query, {"like_string": python_escaped_metric_like})
 
                     results = [dict(row._mapping) for row in result.fetchall()]
 
@@ -8069,14 +8147,19 @@ def get_features_profiles_to_validate(base_name):
         logger.info('fp object :: %s' % str(fps))
     except:
         trace = traceback.format_exc()
+        logger.error(trace)
         fail_msg = 'error :: %s :: error with search_ionosphere' % function_str
         logger.error(fail_msg)
         return (features_profiles_to_validate, fail_msg, trace)
     if not search_success:
         trace = traceback.format_exc()
+        logger.error(trace)
         fail_msg = 'error :: %s :: Webapp error with search_ionosphere' % function_str
         logger.error(fail_msg)
         return (features_profiles_to_validate, fail_msg, trace)
+
+    # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+    logger.info('len(enabled_list): %s' % str(len(enabled_list)))
 
     # Determine the minimum and maximum full durations from the returned fps so
     # this can be used later to determine what class of features profile is
@@ -8169,7 +8252,9 @@ def get_features_profiles_to_validate(base_name):
     # @modified 20210425 - Feature #4014: Ionosphere - inference
     # Added motif_matched_count, motif_last_matched, motif_last_checked, motif_checked_count
     for fp_id, metric_id, metric, fp_full_duration, anomaly_timestamp, tsfresh_version, calc_time, features_count, features_sum, deleted, fp_matched_count, human_date, created_timestamp, fp_checked_count, checked_human_date, fp_parent_id, fp_generation, fp_validated, fp_layers_id, layer_matched_count, layer_human_date, layer_check_count, layer_checked_human_date, layer_label, motif_matched_count, motif_last_matched, motif_last_checked, motif_checked_count in fps:
-        if int(fp_parent_id) == 0:
+        # @modified 20260710 - Feature #5644: ionosphere.learn_self_validation
+        #if int(fp_parent_id) == 0:
+        if int(fp_parent_id) == 0 and int(fp_generation) == 0:
             continue
         if int(fp_validated) == 1:
             continue
@@ -8180,6 +8265,12 @@ def get_features_profiles_to_validate(base_name):
 
         parent_fp_details_object = None
         parent_parent_fp_id = None
+
+        # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+        # If this is a learnt fp use it's own id
+        if int(fp_parent_id) == 0 and int(fp_generation) > 0:
+            fp_parent_id = int(fp_id)
+
         try:
             parent_fp_details, success, fail_msg, trace, parent_fp_details_object = features_profile_details(fp_parent_id)
         except:
@@ -8216,7 +8307,6 @@ def get_features_profiles_to_validate(base_name):
             logger.error('error :: %s :: failed to get parent_parent_fp_id from parent_fp_details_object[\'parent_id\'] - %s' % (
                 function_str, err))
             parent_parent_fp_id = 0
-
         logger.debug('debug :: ionosphere_backend :: get_features_profiles_to_validate :: parent_parent_fp_id: %s' % str(parent_parent_fp_id))
 
         if int(parent_parent_fp_id) == 0:
@@ -8280,6 +8370,30 @@ def get_features_profiles_to_validate(base_name):
         fp_learn_graph_uri = 'ionosphere_images?image=%s/%s.graphite_now.%sh.png' % (
             str(fp_data_dir), base_name, get_hours)
 
+        # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+        image_file = '%s/%s.graphite_now.%sh.png' % (
+            str(fp_data_dir), base_name, get_hours)
+        if not path.isfile(image_file):
+            image_file = '%s/%s.mirage.graphite.%sh.png' % (
+                str(fp_data_dir), base_name, get_hours)
+            if path.isfile(image_file):
+                fp_learn_graph_uri = 'ionosphere_images?image=%s/%s.mirage.graphite.%sh.png' % (
+                    str(fp_data_dir), base_name, get_hours)
+                fp_graph_uri = str(fp_learn_graph_uri)
+            else:
+                # Handle labelled_metrics
+                image_file = None
+                for root, dirs, files in walk(fp_data_dir):
+                    for i_file in files:
+                        if i_file.startswith('labelled_metrics.'):
+                            if i_file.endswith('.matplotlib.png'):
+                                image_file = str(i_file)
+                                break
+                if image_file:
+                    fp_learn_graph_uri = 'ionosphere_images?image=%s/%s' % (
+                        fp_data_dir, image_file)
+                    fp_graph_uri = str(fp_learn_graph_uri)
+
         # For this is a LEARNT feature profile at settings.IONOSPHERE_LEARN_DEFAULT_FULL_DURATION_DAYS
         # the we want to compare the graph to the parent's parent graph at
         # settings.IONOSPHERE_LEARN_DEFAULT_FULL_DURATION_DAYS
@@ -8330,6 +8444,30 @@ def get_features_profiles_to_validate(base_name):
             # str(parent_fp_data_dir), base_name, str(int(parent_full_duration_in_hours)))
             str(parent_fp_data_dir), base_name, get_hours)
 
+        # @added 20260710 - Feature #5644: ionosphere.learn_self_validation
+        if fp_id == fp_parent_id:
+            learnt_image_file = '%s/%s.common_motifs.pw5_timeseries.png' % (
+                str(fp_data_dir), base_name)
+            if path.isfile(learnt_image_file):
+                parent_fp_learn_graph_uri = 'ionosphere_images?image=%s' % (
+                    learnt_image_file)
+                parent_fp_graph_uri = str(parent_fp_learn_graph_uri)
+                parent_full_duration = (86400 * 7) * 5
+            else:
+                learnt_image_file = None
+            if not learnt_image_file:
+                # Handle LEARNT - repetitive pattern
+                for root, dirs, files in walk(fp_data_dir):
+                    for i_file in files:
+                        if i_file.endswith('.graphite_now.720h.png'):
+                            learnt_image_file = str(i_file)
+                            break
+                if learnt_image_file:
+                    parent_fp_learn_graph_uri = 'ionosphere_images?image=%s/%s' % (
+                        fp_data_dir, learnt_image_file)
+                    parent_fp_graph_uri = str(parent_fp_learn_graph_uri)
+                    parent_full_duration = (86400 * 7) * 4
+
         # @modified 20190601 - Task #3082 - Ionosphere - validate matched table - add generation
         # Added parent_fp_generation
         parent_fp_generation = parent_fp_details_object['generation']
@@ -8339,7 +8477,13 @@ def get_features_profiles_to_validate(base_name):
         # @modified 20190601 - Task #3082 - Ionosphere - validate matched table - add generation
         # Added fp_generation and parent_fp_generation
         if fp_id in enabled_list:
-            features_profiles_to_validate.append([fp_id, metric_id, metric, fp_full_duration, anomaly_timestamp, fp_parent_id, parent_full_duration, parent_anomaly_timestamp, fp_date, fp_graph_uri, parent_fp_date, parent_fp_graph_uri, parent_parent_fp_id, fp_learn_graph_uri, parent_fp_learn_graph_uri, minimum_full_duration, maximum_full_duration, fp_generation, parent_fp_generation])
+            features_profiles_to_validate.append([
+                fp_id, metric_id, metric, fp_full_duration, anomaly_timestamp,
+                fp_parent_id, parent_full_duration, parent_anomaly_timestamp,
+                fp_date, fp_graph_uri, parent_fp_date, parent_fp_graph_uri,
+                parent_parent_fp_id, fp_learn_graph_uri, parent_fp_learn_graph_uri,
+                minimum_full_duration, maximum_full_duration, fp_generation,
+                parent_fp_generation])
 
     logger.info('%s :: features_profiles_to_validate - %s' % (
         function_str, str(features_profiles_to_validate)))
@@ -9296,8 +9440,13 @@ def label_anomalies(start_timestamp, end_timestamp, metrics, namespaces, label):
                 # @added 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                 #                   Task #5628: Build v5.0.0 and test
                 #metrics_like_query = text("""SELECT id FROM metrics WHERE metric LIKE :like_string""")
-                metrics_like_text = f"SELECT id FROM metrics WHERE metric LIKE '{namespace_like}'"
-                metrics_like_query = text(metrics_like_text)
+                # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                #metrics_like_text = f"SELECT id FROM metrics WHERE metric LIKE '{namespace_like}'"
+                # @modified 20260622 - Task #5176: Migrate to sqlalchemy v2 API
+                #                      Task #5628: Build v5.0.0 and test
+                # @modified 20260710 - Task #5176: Migrate to sqlalchemy v2 API
+                #metrics_like_query = text(metrics_like_text)
+                metrics_like_query = text("SELECT id FROM metrics WHERE metric LIKE :like_string")
 
                 #connection = engine.connect()
                 # @modified 20200425 - Ideas #2476: Label and relate anomalies
@@ -9310,7 +9459,10 @@ def label_anomalies(start_timestamp, end_timestamp, metrics, namespaces, label):
                     # @modified 20260423 - Task #5176: Migrate to sqlalchemy v2 API
                     #                      Task #5628: Build v5.0.0 and test
                     #result = connection.execute(metrics_like_query, like_string=str(namespace_like))
-                    result = connection.execute(metrics_like_query)
+                    # @modified 20260622 - Task #5176: Migrate to sqlalchemy v2 API
+                    #                      Task #5628: Build v5.0.0 and test
+                    #result = connection.execute(metrics_like_query)
+                    result = connection.execute(metrics_like_query, {'like_string': namespace_like})
                     results = [dict(row._mapping) for row in result.fetchall()]
 
                 for row in results:
@@ -9725,6 +9877,22 @@ def expected_features_profiles_dirs():
                         metric = metrics[metric_id]['metric']
                     except KeyError:
                         metric = None
+
+                    # @added 20260708 - Bug #5707: create_features_profile - no metric id from DB
+                    fp_row = {}
+                    if not metric and metric_id == 0:
+                        try:
+                            fp_row = get_ionosphere_fp_db_row(skyline_app, fp_id)
+                        except Exception as err:
+                            logger.err('error :: expected_features_profiles_dirs :: get_ionosphere_fp_db_row failed, err: %s' % (err))
+                        if fp_row:
+                            try:
+                                metric_id = fp_row['metric_id']
+                                logger.info('expected_features_profiles_dirs :: determined metric_id from get_ionosphere_fp_db_row, metric_id: %s, fp_id: %s' % (
+                                    str(metric_id), str(fp_id)))
+                            except KeyError:
+                                metric_id = 0
+
                     # @modified 20260211 - Bug #5707: create_features_profile - no metric id from DB
                     #if not metric:
                     if not metric and metric_id:
@@ -9754,6 +9922,25 @@ def expected_features_profiles_dirs():
                     fp_dir = '%s/%s/%s' % (
                         settings.IONOSPHERE_PROFILES_FOLDER, metric_timeseries_dir,
                         str(timestamp))
+
+                    # @added 20260708 - Bug #5707: create_features_profile - no metric id from DB
+                    # Do not add the fp if there is no directory for the fp
+                    if not path.isdir(fp_dir):
+
+                        fp_enabled = fps[fp_id]['enabled']
+                        if fp_row:
+                            fp_enabled = fp_row['enabled']
+                        if fp_enabled == 0:
+                            logger.warning('warning :: expected_features_profiles_dirs :: fp_id: %s, fp_dir does not exist: %s' % (
+                                str(fp_id), str(fp_dir)))
+                            continue
+                        else:
+                            logger.debug('debug :: expected_features_profiles_dirs :: fp_id: %s, fp_dir does not exist: %s, fps[fp_id]["enabled"]: %s' % (
+                                str(fp_id), str(fp_dir), str(fps[fp_id]['enabled'])))
+                            if fp_row:
+                                logger.debug('debug :: expected_features_profiles_dirs :: fp_id: %s, fp_dir does not exist: %s, fp_row["enabled"]: %s' % (
+                                    str(fp_id), str(fp_dir), str(fp_row['enabled'])))
+
                     # @modified 20220503 - Feature #3890: metrics_manager - sync_cluster_files
                     # Use a str for jsonify
                     # features_profile_dirs_dict[fp_id] = fp_dir

--- a/skyline/webapp/templates/api.html
+++ b/skyline/webapp/templates/api.html
@@ -23,6 +23,7 @@
     it is only referenced if Skyline is running in clustered mode, if not it is simply ignored.<br>
     If any below API methods do not have it specified it means that each individual node of the cluster has to be queried
     for that method.<br>
+	Not all API methods are documented here, this is only a selection of some methods.<br>
 
 	  <h4><span class="logo"><span class="sky">API method ::</span> <span class="re">/api?airgapped_metrics</span></span></h4>
   		  <table class="table table-hover">
@@ -2277,7 +2278,10 @@ Or if no metrics with training data are present <code>{"data":{"metrics":[]},"st
   		      <tr>
   		        <td>Description:</td>
   		        <td>Returns a list of all metrics (with their FULL_NAMESPACE metric name) as a json object.
-              Optionally you can filter on namepsace elements and remove the FULL_NAMESPACE</td>
+              Optionally you can filter on namepsace elements and remove the FULL_NAMESPACE.  Only Redis (dotted namespace)
+			  metrics are returned, RedisTimeseries (Prometheus/VictorMetrics/labelled_metrcis) are not returned by this
+			  method.
+				</td>
   		      </tr>
   		      <tr>
   		        <td>Endpoint:</td>

--- a/skyline/webapp/templates/validate_common_motifs.html
+++ b/skyline/webapp/templates/validate_common_motifs.html
@@ -101,6 +101,13 @@
   		<div class="col-md-12">
 <!--  		<div class="container"> -->
   		  <h4><span class="logo"><span class="sky">Search ::</span> <span class="re">common_motifs features profiles to validate</span></span></h4>
+        <br>
+        Make sure that you periodically review the autonomously learnt and self validated features profiles by setting the <code>self_validated_only</code> to <code>true</code>
+        and setting the approriate dates since the last review in the search options.  Although very rare, incorrect patterns are learnt occassionally , whether that be contextually incorrect or
+        just plain incorrect, it does happen.
+        <br>
+        <center><strong><code>REVIEW AUTONOMOUSLY LEARNT AND SELF VALDIATED PATTERNS PERIODICALLY.</code></strong></center>
+        <br>
   {% if limited_common_motifs_fps|length > 0 %}
     {% if version == dev_ver %}
         <button type="button" class="btn btn-info" data-bs-toggle="collapse" data-bs-target="#search_options">Show search options</button>
@@ -147,6 +154,13 @@
   		      <tr>
                 <td>limit</td>
                 <td><input type="number" name="limit" min="0" max="100" value="15" /> use 0 for unlimited</td>
+  		      </tr>
+  		      <tr>
+                <td>self_validated_only</td>
+                <td><select name="self_validated_only">
+                  <option value="false">false</option>
+                  <option value="true">true</option>
+                </select> return only self_validated fps <strong><code>REVIEW AUTONOMOUSLY LEARNT AND SELF VALDIATED PATTERNS PERIODICALLY.</code></strong></td>
   		      </tr>
   		      <tr>
   		        <td>Show graphs</td>
@@ -212,6 +226,12 @@
     {% else %}
       {% set use_metric = limited_common_motifs_fps[fp_id]['metric'] %}
     {% endif %}
+    {% if limited_common_motifs_fps[fp_id]['self_validated'] %}
+      {% set validated_button_label = 'SELF_VALIDATED' %}
+    {% else %}
+      {% set validated_button_label = 'VALIDATED' %}
+    {% endif %}
+
           <tr>
             <td onclick="window.location='?fp_view=true&fp_id={{ fp_id }}&metric={{ use_metric }}'">
               <a href="?fp_view=true&fp_id={{ fp_id }}&metric={{ use_metric }}">{{ fp_id }}</a>
@@ -234,7 +254,7 @@
               <button type="button">Validate</button></a>
             {% endif %}
             {% if state == 'validated' %}
-              <button type="button" disabled><span class="logo"><span class="sky"></span>VALIDATED</span></span></button></a>
+              <button type="button" disabled><span class="logo"><span class="sky"></span>{{ validated_button_label }}</span></span></button></a>
             {% endif %}
             {% if state == 'invalid' %}
             <button type="button" disabled><span class="logo"><span class="re"></span>INVALID</span></span></button></a>

--- a/skyline/webapp/templates/validate_features_profiles.html
+++ b/skyline/webapp/templates/validate_features_profiles.html
@@ -366,14 +366,14 @@
             <td>
               {{ item[10] }}<br>
     {% if item[3] == item[16] %}
-              <br><span class="logo"><span class="sky">LEARNT</span> <span class="re">with</span></span> resolution ({{ item[3] / 60 / 60 }} hours):<br>
+              <br><span class="logo"><span class="sky">LEARNT</span> <span class="re">with</span></span> resolution ({{ item[6] / 60 / 60 }} hours):<br>
     {% else %}
               <br>{{ item[15] / 60 / 60 }} hours at this time was:<br>
     {% endif %}
               <img src="{{ item[11] }}" loading="lazy" alt="{{ for_metric }} timeseries graph" style="float: left; width: 100%; margin-right: 1%; margin-bottom: 0.5em;">
               <br>{{ item[11] }}
     {% if item[3] == item[16] %}
-              <br>{{ item[15] / 60 / 60 }} hours at this time was:<br>
+              <br>{{ item[6] / 60 / 60 }} hours at this time was:<br>
     {% else %}
               <br><span class="logo"><span class="sky">LEARNT</span> <span class="re">with</span></span> resolution ({{ item[3] / 60 / 60 }} hours):<br>
     {% endif %}

--- a/skyline/webapp/webapp.py
+++ b/skyline/webapp/webapp.py
@@ -6176,9 +6176,9 @@ def mock_api():
             'full_duration': 86400,
             'second_order_resolution_seconds': 604800,
             'learn_full_duration_seconds': 2592000,
-            'flux_token': None,
+            'flux_token': None,  # nosec
             "thunder_alert_endpoint": 'http://127.0.0.1:1500/mock_api?alert_reciever',
-            'thunder_alert_token': None,
+            'thunder_alert_token': None,  # nosec
             'alert_on_no_data': {
                 'enabled': True,
                 'stale_period': 300,
@@ -6297,6 +6297,7 @@ def panorama():
     # @added 20260221 - Feature #5712: skyline.dawn
     analyzer_dawn_expiry_date = None
     mirage_dawn_expiry_date = None
+    panorama_dawn_expiry_date = None
     if SKYLINE_DAWN_ENABLED:
         # First check to the Panorama and Mirage expiries
         try:
@@ -8458,6 +8459,15 @@ def ionosphere():
         else:
             use_namespace = str(namespace)
         state = request.args.get('state', 'unvalidated')
+
+        # @added 20260705 - Feature #5644: ionosphere.learn_self_validation
+        #                   Feature #5318: common_motifs
+        self_validated_only = request.args.get('self_validated_only', False)
+        if self_validated_only == 'true':
+            self_validated_only = True
+        if self_validated_only == 'false':
+            self_validated_only = False
+
         from_timestamp = request.args.get('from_timestamp', 'all')
         if ":" in from_timestamp:
             # @modified 20260221 - Task #5711: Test Ubuntu 24.04
@@ -8498,7 +8508,10 @@ def ionosphere():
         logger.info('validate_common_motifs_fps request with limit: %s, namespace: %s' % (
             str(limit_to), str(namespace)))
         try:
-            common_motifs_fps = get_common_motifs_to_validate(from_timestamp, until_timestamp, state=state, namespace=use_namespace)
+            # @modified 20260705 - Feature #5644: ionosphere.learn_self_validation
+            #                      Feature #5318: common_motifs
+            # Added self_validated_only
+            common_motifs_fps = get_common_motifs_to_validate(from_timestamp, until_timestamp, state=state, namespace=use_namespace, self_validated_only=self_validated_only)
         except Exception as err:
             trace = traceback.format_exc()
             fail_msg = 'error :: get_common_motifs_to_validate falied, err: %s' % err
@@ -8535,6 +8548,8 @@ def ionosphere():
             ionosphere_dawn_expiry_date=ionosphere_dawn_expiry_date,
             ionosphere_learn_dawn_expiry_date=ionosphere_learn_dawn_expiry_date,
             ionosphere_learn_repetitive_patterns_dawn_expiry_date=ionosphere_learn_repetitive_patterns_dawn_expiry_date,
+            # @added 20260705 - Feature #5644: ionosphere.learn_self_validation
+            self_validated_only=self_validated_only,
             duration=(time.time() - start), print_debug=False), 200
 
     # @added 20180812 - Feature #2430: Ionosphere validate learnt features profiles page
@@ -8701,6 +8716,8 @@ def ionosphere():
 
             features_profiles_to_validate = []
             if metric_name != 'all':
+                logger.info('running get_features_profiles_to_validate for %s' % (
+                    base_name))
                 try:
                     features_profiles_to_validate, fail_msg, trace = get_features_profiles_to_validate(base_name)
                     # features_profiles_to_validate
@@ -11584,6 +11601,15 @@ def ionosphere():
                     validate = True
                     logger.info('validate - %s' % str(validate))
             if validate:
+
+                # @modified 202600705 - Feature #5644: ionosphere.learn_self_validation
+                #                       Feature #5318: common_motifs
+                # Added self_validated
+                self_validated = False
+                self_validated_arg = request.args.get('self_validated', False)
+                if self_validated_arg == 'true':
+                    self_validated = True
+
                 logger.info('validating - fp_ip %s' % str(fp_id))
                 try:
                     # @modified 20181013 - Feature #2430: Ionosphere validate learnt features profiles page
@@ -11594,7 +11620,11 @@ def ionosphere():
                     #                      Feature #2516: Add label to features profile
                     # Added user_id
                     # validated_fp_success, fail_msg, traceback_format_exc = validate_fp(fp_id, 'id')
-                    validated_fp_success, fail_msg, traceback_format_exc = validate_fp(fp_id, 'id', user_id)
+                    # @modified 202600705 - Feature #5644: ionosphere.learn_self_validation
+                    #                       Feature #5318: common_motifs
+                    # Added self_validated
+                    #validated_fp_success, fail_msg, traceback_format_exc = validate_fp(fp_id, 'id', user_id)
+                    validated_fp_success, fail_msg, traceback_format_exc = validate_fp(fp_id, 'id', user_id, self_validated=self_validated)
                     logger.info('validated fp_id - %s' % str(fp_id))
                 except:
                     trace = traceback.format_exc()
@@ -17184,7 +17214,7 @@ def llm_chat_query():
         else:
             history = session.get(SESSION_KEY_HISTORY, [])
 
-        logger.info(f"/llm_chat_query request, history: {str(history)}")
+        #logger.info(f"/llm_chat_query request, history: {str(history)}")
 
         # Run the agentic turn
         result = run_chat_turn(provider_llm_model, llm_model, user_message, history, settings)
@@ -17219,12 +17249,22 @@ def llm_chat_query():
                 result['query_results_csvs'][csv]['result'] = query_result
             query_results = result['query_results_csvs']
 
+        # @added 20260628 - Task #5709: POC LLM integration
+        # Add reasoning/thinking to the output to allow the user to review
+        # and validate the thinking and ensure no hallucinations or
+        # incorrect columns, etc are being used
+        reasoning_contents = []
+        if 'tools_reasoning_content' in result:
+            reasoning_contents = result['tools_reasoning_content']
+
         return jsonify({
             'response': result['response'],
             'tool_calls_made': result['tool_calls_made'],
             'error': result['error'],
             'llm_results': llm_results,
             'query_results': query_results,
+            'reasoning_contents': reasoning_contents,
+            'llm_model': result['llm_model'],
         }), 200
 
     except Exception:
@@ -18285,7 +18325,7 @@ def urlsafe_base64_encode(s):
         s = decoded_s
         # logger.info('debug more :: rebrow :: %s urlsafe_b64encode decoded as %s' % (str(s_original), str(decoded_s)))
 
-    return Markup(s)
+    return Markup(s)  # nosec
 # END rebrow
 
 


### PR DESCRIPTION
IssueID #5318: common_motifs

- Added self_valdiated field and parameters for self_validated_only

IssueID #5709: POC LLM integration

- Added reasoning output

IssueID #5176: Migrate to sqlalchemy v2 API

- Updated like queries

IssueID #5707: create_features_profile - no metric id from DB

Modified:
skyline/functions/database/queries/get_all_fps.py
skyline/ionosphere/learn_self_validation.py
skyline/tsfresh_features/autobuild_features_profile_tables.py skyline/webapp/backend.py
skyline/webapp/common_motifs_to_validate.py
skyline/webapp/crucible_backend.py
skyline/webapp/ionosphere_backend.py
skyline/webapp/templates/api.html
skyline/webapp/templates/validate_common_motifs.html skyline/webapp/templates/validate_features_profiles.html skyline/webapp/webapp.py

IssueID #5764: get_ionosphere_disabled_fp_ids

Added:
skyline/functions/database/queries/get_ionosphere_disabled_fp_ids.py